### PR TITLE
Add GitHub repository link to About page

### DIFF
--- a/web/src/pages/About.tsx
+++ b/web/src/pages/About.tsx
@@ -82,6 +82,36 @@ const About: Component = () => {
                 discretion and for entertainment purposes only.
               </p>
             </div>
+
+            <div>
+              <h2 class="text-2xl font-display text-parchment-100 mb-4">Open Source</h2>
+              <p class="leading-relaxed">
+                Artificial University is an open-source project. You can view the source code,
+                report issues, or contribute to development on GitHub.
+              </p>
+              <div class="mt-4">
+                <a
+                  href="https://github.com/ballPointPenguin/artificial-u"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center gap-2 text-parchment-200 hover:text-parchment-100 underline decoration-parchment-400 hover:decoration-parchment-200 transition-colors duration-200"
+                >
+                  <svg
+                    class="w-5 h-5"
+                    fill="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path
+                      fill-rule="evenodd"
+                      d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+                      clip-rule="evenodd"
+                    />
+                  </svg>
+                  View on GitHub
+                </a>
+              </div>
+            </div>
           </div>
 
           <div class="mt-12 text-center">


### PR DESCRIPTION
- Added new "Open Source" section with link to GitHub repository
- Included GitHub icon for better visual recognition
- Link opens in new tab with proper security attributes
- Styled to match existing page theme