### PR TITLE
Fix PWA service worker caching issue on production

### DIFF
--- a/cdk/cdk/cdk_stack.py
+++ b/cdk/cdk/cdk_stack.py
@@ -351,7 +351,14 @@ class CdkStack(Stack):
             destination_bucket=frontend_bucket,
             prune=False,  # Don't prune to avoid removing assets
             distribution=distribution,
-            distribution_paths=["/", "/index.html"],
+            distribution_paths=[
+                "/",
+                "/index.html",
+                "/sw.js",  # Service worker must be invalidated for PWA updates
+                "/workbox-*.js",  # Workbox runtime files
+                "/manifest.json",  # PWA manifest
+                "/registerSW.js",  # SW registration script (if generated)
+            ],
             cache_control=[
                 s3_deployment.CacheControl.from_string("no-cache, no-store, must-revalidate"),
             ],


### PR DESCRIPTION
The production site wasn't showing the new audio player because CloudFront was caching the old service worker files indefinitely. This prevented the PWA update mechanism from working.

Changes:
- Add service worker files to CloudFront invalidation paths
- Include sw.js, workbox-*.js, manifest.json, and registerSW.js
- These files now use no-cache headers, ensuring users get updates

This ensures that when new features are deployed, the service worker is properly invalidated and users see the update prompt.