### PR TITLE
Add CORS configuration to S3 buckets for audio playback

### DIFF
--- a/cdk/cdk/cdk_stack.py
+++ b/cdk/cdk/cdk_stack.py
@@ -77,6 +77,7 @@ class CdkStack(Stack):
 
         # 4. Create S3 Buckets for application storage (replacing MinIO)
         # Audio, lectures, and images buckets are publicly readable for web interface
+        # CORS configuration is required for browser access to media files
         audio_bucket = s3.Bucket(
             self,
             "AudioBucket",
@@ -89,6 +90,15 @@ class CdkStack(Stack):
                 ignore_public_acls=False,
                 restrict_public_buckets=False,
             ),
+            cors=[
+                s3.CorsRule(
+                    allowed_origins=[f"https://{domain_name}", f"https://{site_domain}"],
+                    allowed_methods=[s3.HttpMethods.GET, s3.HttpMethods.HEAD],
+                    allowed_headers=["*"],
+                    exposed_headers=["Content-Length", "Content-Range", "Accept-Ranges"],
+                    max_age=3600,
+                )
+            ],
         )
         lectures_bucket = s3.Bucket(
             self,
@@ -102,6 +112,15 @@ class CdkStack(Stack):
                 ignore_public_acls=False,
                 restrict_public_buckets=False,
             ),
+            cors=[
+                s3.CorsRule(
+                    allowed_origins=[f"https://{domain_name}", f"https://{site_domain}"],
+                    allowed_methods=[s3.HttpMethods.GET, s3.HttpMethods.HEAD],
+                    allowed_headers=["*"],
+                    exposed_headers=["Content-Length", "Content-Range", "Accept-Ranges"],
+                    max_age=3600,
+                )
+            ],
         )
         images_bucket = s3.Bucket(
             self,
@@ -115,6 +134,15 @@ class CdkStack(Stack):
                 ignore_public_acls=False,
                 restrict_public_buckets=False,
             ),
+            cors=[
+                s3.CorsRule(
+                    allowed_origins=[f"https://{domain_name}", f"https://{site_domain}"],
+                    allowed_methods=[s3.HttpMethods.GET, s3.HttpMethods.HEAD],
+                    allowed_headers=["*"],
+                    exposed_headers=["Content-Length"],
+                    max_age=3600,
+                )
+            ],
         )
         exports_bucket = s3.Bucket(
             self,


### PR DESCRIPTION
The audio player was being blocked by CORS policy when trying to fetch MP3 files from S3. This is because the buckets were publicly readable but didn't have CORS headers configured.

Changes:
- Add CORS rules to audio_bucket, lectures_bucket, and images_bucket
- Allow GET and HEAD methods (required for audio range requests)
- Expose Content-Length, Content-Range, Accept-Ranges headers
- Allow requests from both artificial-u.com and www.artificial-u.com
- Set CORS cache to 1 hour

This enables the HTML5 audio player to:
- Make range requests for seeking/scrubbing
- Load audio from S3 without CORS errors
- Properly display playback progress