### PR TITLE
Add ElevenLabs Voice ID display to professor details view

### DIFF
--- a/web/src/components/professors/ProfessorDetail.tsx
+++ b/web/src/components/professors/ProfessorDetail.tsx
@@ -519,6 +519,22 @@ export default function ProfessorDetail() {
                                 </p>
                               </Show>
 
+                              <Show when={voice().el_voice_id}>
+                                <p class="text-sm text-muted">
+                                  <strong class="font-semibold text-foreground">
+                                    ElevenLabs Voice ID:
+                                  </strong>{' '}
+                                  <a
+                                    href={`https://elevenlabs.io/app/voice-library?voiceId=${voice().el_voice_id ?? ''}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="text-accent hover:text-accent/80 underline"
+                                  >
+                                    {voice().el_voice_id}
+                                  </a>
+                                </p>
+                              </Show>
+
                               <Show when={voice().accent}>
                                 <p class="text-sm text-muted">
                                   <strong class="font-semibold text-foreground">Accent:</strong>{' '}
@@ -659,6 +675,22 @@ export default function ProfessorDetail() {
                               <p class="text-sm text-muted">
                                 <strong class="font-semibold text-foreground">Name:</strong>{' '}
                                 {voice().name}
+                              </p>
+                            </Show>
+
+                            <Show when={voice().el_voice_id}>
+                              <p class="text-sm text-muted">
+                                <strong class="font-semibold text-foreground">
+                                  ElevenLabs Voice ID:
+                                </strong>{' '}
+                                <a
+                                  href={`https://elevenlabs.io/app/voice-library?voiceId=${voice().el_voice_id ?? ''}`}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  class="text-accent hover:text-accent/80 underline"
+                                >
+                                  {voice().el_voice_id}
+                                </a>
                               </p>
                             </Show>
 


### PR DESCRIPTION
Display the ElevenLabs Voice ID (el_voice_id) in the professor details Voice Profile section with a clickable link to the ElevenLabs voice library. The link opens in a new tab for convenient access to the voice details.

Updated both desktop and mobile responsive versions of the Voice Profile.