### PR TITLE
Fix batch regeneration ordering bug and add job cancellation UI

### DIFF
--- a/artificial_u/api/worker.py
+++ b/artificial_u/api/worker.py
@@ -389,7 +389,8 @@ class Worker:
         new_remaining: list[int],
     ) -> Dict[str, Any]:
         """Build payload for lecture generation follow-up job."""
-        partial_attrs = follow_up.get("partial_attributes", {})
+        # Make a copy to avoid mutating the original follow_up dict
+        partial_attrs = follow_up.get("partial_attributes", {}).copy()
         partial_attrs["topic_id"] = next_topic_id
 
         payload = {
@@ -399,10 +400,17 @@ class Worker:
         }
 
         if new_remaining:
-            payload["follow_up"] = {
-                **follow_up,
+            # Create new follow_up with copied partial_attributes to avoid mutation
+            new_follow_up = {
+                "action": follow_up.get("action"),
+                "course_id": follow_up.get("course_id"),
+                "created_by": follow_up.get("created_by"),
+                "partial_attributes": follow_up.get("partial_attributes", {}).copy(),
                 "remaining_topic_ids": new_remaining,
             }
+            if "freeform_prompt" in follow_up:
+                new_follow_up["freeform_prompt"] = follow_up["freeform_prompt"]
+            payload["follow_up"] = new_follow_up
 
         return payload
 

--- a/web/src/api/config.ts
+++ b/web/src/api/config.ts
@@ -88,6 +88,7 @@ export const ENDPOINTS = {
     detail: (id: number) => `/v1/jobs/${String(id)}`,
     summary: '/v1/jobs/summary',
     stream: '/v1/jobs/stream',
+    cancel: (id: number) => `/v1/jobs/${String(id)}/cancel`,
   },
   lectures: {
     list: '/v1/lectures',

--- a/web/src/api/services/jobs-service.ts
+++ b/web/src/api/services/jobs-service.ts
@@ -34,6 +34,11 @@ export async function listJobs(params?: {
   return httpClient.get<JobRow[]>(endpoint)
 }
 
+export async function cancelJob(jobId: number): Promise<{ id: number; status: string }> {
+  const endpoint = ENDPOINTS.jobs.cancel(jobId)
+  return httpClient.post<{ id: number; status: string }>(endpoint, {})
+}
+
 // SSE subscription helper for job events
 export type JobEvent = {
   id: number

--- a/web/src/pages/Jobs.tsx
+++ b/web/src/pages/Jobs.tsx
@@ -1,5 +1,5 @@
 import { createResource, createSignal, For, Show } from 'solid-js'
-import { type JobRow, type JobStatus, listJobs } from '../api/services/jobs-service'
+import { cancelJob, type JobRow, type JobStatus, listJobs } from '../api/services/jobs-service'
 import { Button } from '../components/ui'
 import { formatDate } from '../utils/formatDate'
 
@@ -13,6 +13,7 @@ const STATUS_STYLES: Record<JobStatus, string> = {
 
 export default function JobsPage() {
   const [statusFilter, setStatusFilter] = createSignal<JobStatus | undefined>(undefined)
+  const [cancellingJobId, setCancellingJobId] = createSignal<number | null>(null)
 
   const [jobsResource, { refetch }] = createResource(
     () => ({
@@ -24,6 +25,23 @@ export default function JobsPage() {
 
   const handleStatusFilter = (status: JobStatus | undefined) => {
     setStatusFilter(status)
+  }
+
+  const handleCancelJob = async (jobId: number) => {
+    if (!confirm('Are you sure you want to cancel this job?')) {
+      return
+    }
+
+    setCancellingJobId(jobId)
+    try {
+      await cancelJob(jobId)
+      void refetch() // Refresh the job list
+    } catch (error) {
+      console.error('Failed to cancel job:', error)
+      alert('Failed to cancel job. Please try again.')
+    } finally {
+      setCancellingJobId(null)
+    }
   }
 
   return (
@@ -164,6 +182,12 @@ export default function JobsPage() {
                     >
                       Error
                     </th>
+                    <th
+                      scope="col"
+                      class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider"
+                    >
+                      Actions
+                    </th>
                   </tr>
                 </thead>
                 <tbody class="bg-background divide-y divide-border">
@@ -191,6 +215,18 @@ export default function JobsPage() {
                         </td>
                         <td class="px-6 py-4 text-sm text-muted max-w-xs truncate">
                           {job.last_error || '-'}
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm">
+                          <Show when={job.status === 'queued' || job.status === 'running'}>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => void handleCancelJob(job.id)}
+                              disabled={cancellingJobId() === job.id}
+                            >
+                              {cancellingJobId() === job.id ? 'Cancelling...' : 'Cancel'}
+                            </Button>
+                          </Show>
                         </td>
                       </tr>
                     )}


### PR DESCRIPTION
This commit addresses two issues:

1. **Fix ordering mismatch bug in batch regeneration**
   - Fixed dict mutation bug in worker.py _build_lecture_payload()
   - The method was mutating the shared partial_attributes dict from follow_up, causing topic_id to leak between sequential jobs
   - Now creates a copy before mutating to prevent cross-contamination
   - This ensures each lecture is generated for the correct topic

2. **Add job cancellation UI**
   - Added cancelJob() function to jobs-service.ts
   - Added cancel endpoint to API config
   - Added "Cancel" button to Jobs page for queued/running jobs
   - Shows cancellation state with loading indicator
   - Refreshes job list after successful cancellation

The backend already had full cancellation support (POST /jobs/{id}/cancel), this change adds the missing frontend UI.