### PR TITLE
Add Generate Summary button to LectureSection

### DIFF
--- a/web/src/api/config.ts
+++ b/web/src/api/config.ts
@@ -99,6 +99,7 @@ export const ENDPOINTS = {
     audio: (id: number) => `/v1/lectures/${String(id)}/audio`,
     generateAudio: (id: number) => `/v1/lectures/${String(id)}/generate-audio`,
     enqueueGenerateAudio: (id: number) => `/v1/lectures/${String(id)}/generate-audio/enqueue`,
+    generateSummary: (id: number) => `/v1/lectures/${String(id)}/generate-summary`,
     uploadAudio: (id: number) => `/v1/lectures/${String(id)}/upload-audio`,
     download: (id: number) => `/v1/lectures/${String(id)}/content/download`,
   },

--- a/web/src/api/services/lecture-service.ts
+++ b/web/src/api/services/lecture-service.ts
@@ -148,4 +148,16 @@ export const lectureService = {
       TIMEOUT_CONFIG.upload
     )
   },
+
+  /**
+   * Trigger generation of lecture summary. No body required.
+   * Uses extended timeout similar to other generation actions.
+   */
+  generateSummary: (lectureId: number, onTimeout?: () => void): Promise<Lecture> => {
+    return httpClient.postWithExtendedTimeout<Lecture>(
+      ENDPOINTS.lectures.generateSummary(lectureId),
+      undefined,
+      { timeout: TIMEOUT_CONFIG.generation, onTimeout }
+    )
+  },
 }

--- a/web/src/components/lectures/LectureSection.tsx
+++ b/web/src/components/lectures/LectureSection.tsx
@@ -34,6 +34,8 @@ export const LectureSection: Component<LectureSectionProps> = (props) => {
   const [audioTimeout, setAudioTimeout] = createSignal(false)
   const [isUploadingAudio, setIsUploadingAudio] = createSignal(false)
   const [uploadSuccess, setUploadSuccess] = createSignal(false)
+  const [isGeneratingSummary, setIsGeneratingSummary] = createSignal(false)
+  const [summaryError, setSummaryError] = createSignal('')
 
   // Track jobs for this topic AND lecture (lecture ID will be undefined initially,
   // then change when created)
@@ -64,6 +66,8 @@ export const LectureSection: Component<LectureSectionProps> = (props) => {
 
       if (event.kind === 'generate_lecture_audio') {
         setAudioError(getJobMessage(event.kind, 'failed'))
+      } else if (event.kind === 'generate_lecture_summary') {
+        setSummaryError(getJobMessage(event.kind, 'failed'))
       }
     },
     onJobStart: (event) => {
@@ -149,6 +153,24 @@ export const LectureSection: Component<LectureSectionProps> = (props) => {
       setAudioError(error instanceof Error ? error.message : 'Failed to upload audio')
     } finally {
       setIsUploadingAudio(false)
+    }
+  }
+
+  const handleGenerateSummary = async () => {
+    const lecture = props.lecture()
+    if (!lecture) return
+
+    setIsGeneratingSummary(true)
+    setSummaryError('')
+
+    try {
+      await lectureService.generateSummary(lecture.id)
+      // Refresh lecture data to show the new summary
+      props.onLectureUpdated?.()
+    } catch (error) {
+      setSummaryError(error instanceof Error ? error.message : 'Failed to generate summary')
+    } finally {
+      setIsGeneratingSummary(false)
     }
   }
 
@@ -301,6 +323,13 @@ export const LectureSection: Component<LectureSectionProps> = (props) => {
         </Alert>
       </Show>
 
+      {/* Summary generation error messages */}
+      <Show when={summaryError()}>
+        <Alert variant="danger" class="mb-4">
+          {summaryError()}
+        </Alert>
+      </Show>
+
       <Show when={props.lecture()}>
         {(lectureData) => (
           <div class="space-y-4">
@@ -316,6 +345,20 @@ export const LectureSection: Component<LectureSectionProps> = (props) => {
                 <p class="mt-3 text-parchment-200 font-serif whitespace-pre-wrap">
                   {lectureData().summary}
                 </p>
+              </Show>
+              <Show when={!lectureData().summary}>
+                <RequireRole minRole="creator">
+                  <div class="mt-3">
+                    <MagicButton
+                      variant="primary"
+                      size="sm"
+                      onClick={() => void handleGenerateSummary()}
+                      disabled={isGeneratingSummary() || anyJobActive()}
+                    >
+                      {isGeneratingSummary() ? 'Generating Summary...' : 'Generate Summary'}
+                    </MagicButton>
+                  </div>
+                </RequireRole>
               </Show>
             </div>
 


### PR DESCRIPTION
Adds a "Generate Summary" button that appears when a lecture has no summary. The button is wrapped in RequireRole with minRole="creator" as requested.

Changes:
- Add generateSummary endpoint to API config
- Add generateSummary service method to lecture-service
- Add summary generation handler and error handling to LectureSection
- Display "Generate Summary" button when summary is missing
- Track summary generation jobs and display appropriate states

The button triggers the existing backend endpoint for generating lecture summaries.