### PR TITLE
Fix CloudFront cache policy configuration error

### DIFF
--- a/cdk/cdk/cdk_stack.py
+++ b/cdk/cdk/cdk_stack.py
@@ -316,9 +316,7 @@ class CdkStack(Stack):
             default_ttl=cdk.Duration.seconds(0),
             min_ttl=cdk.Duration.seconds(0),
             max_ttl=cdk.Duration.seconds(0),
-            # Important: respect Cache-Control headers from origin
-            enable_accept_encoding_gzip=True,
-            enable_accept_encoding_brotli=True,
+            # Note: compression settings cannot be enabled when caching is disabled
         )
 
         # 12. Create a CloudFront distribution


### PR DESCRIPTION
Remove enable_accept_encoding_gzip and enable_accept_encoding_brotli from PWACachePolicy as these parameters are invalid when caching is disabled (all TTL values set to 0). CloudFront compression settings only apply to cached content.

This fixes the deployment error:
"The parameter EnableAcceptEncodingGzip is invalid for policy with caching disabled."