### PR TITLE
Fix audio count ratio calculation for courses

### DIFF
--- a/artificial_u/models/repositories/course.py
+++ b/artificial_u/models/repositories/course.py
@@ -171,10 +171,11 @@ class CourseRepository(BaseRepository):
         """
         with self.get_session() as session:
             # Subquery for lectures with audio
+            # Count distinct topics (not total lectures) to handle multiple revisions
             lectures_audio_sq = (
                 session.query(
                     LectureModel.course_id,
-                    func.count(LectureModel.id).label("audio_count"),
+                    func.count(func.distinct(LectureModel.topic_id)).label("audio_count"),
                 )
                 .filter(LectureModel.audio_url.isnot(None))
                 .group_by(LectureModel.course_id)


### PR DESCRIPTION
The audio count was incorrectly counting all lectures with audio URLs, resulting in inflated ratios when multiple lecture revisions exist for the same topic (e.g., "38/24" for a 24-topic course).

Changed the calculation to count distinct topics with audio instead of total lectures. Now uses COUNT(DISTINCT topic_id) instead of COUNT(id), ensuring each topic is counted at most once regardless of revisions.

This provides accurate audio coverage ratios that reflect the number of topics covered, not the total number of lecture files.