### PR TITLE
Add status field to courses table

### DIFF
--- a/alembic/versions/pxfhh15d6yq2_add_status_field_to_courses.py
+++ b/alembic/versions/pxfhh15d6yq2_add_status_field_to_courses.py
@@ -1,0 +1,30 @@
+"""add_status_field_to_courses
+
+Revision ID: pxfhh15d6yq2
+Revises: 3f18c21ab01a
+Create Date: 2025-11-25 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "pxfhh15d6yq2"
+down_revision = "3f18c21ab01a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add status column with default 'hidden' for new rows
+    # But set existing courses to 'published'
+    op.add_column("courses", sa.Column("status", sa.String(), nullable=False, server_default="hidden"))
+
+    # Update existing courses to 'published'
+    op.execute("UPDATE courses SET status = 'published'")
+
+
+def downgrade() -> None:
+    op.drop_column("courses", "status")

--- a/artificial_u/api/models/courses.py
+++ b/artificial_u/api/models/courses.py
@@ -3,7 +3,7 @@ API models for Course resources.
 """
 
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -41,6 +41,9 @@ class CourseBase(BaseModel):
         description="Total number of weeks in the course (1-50)",
     )
     topics: Optional[List[Dict[str, Any]]] = Field(None, description="List of course topics")
+    status: Literal["hidden", "published"] = Field(
+        default="hidden", description="Course visibility status"
+    )
     # Attribution (not required for create)
     created_by: Optional[int] = Field(None, description="Student ID who created the course")
     created_with: Optional[str] = Field(None, description="Name of LLM used, if any")
@@ -83,6 +86,9 @@ class CourseUpdate(BaseModel):
         ge=1,
         le=50,
         description="Updated total weeks (1-50)",
+    )
+    status: Optional[Literal["hidden", "published"]] = Field(
+        None, description="Updated course visibility status"
     )
 
 

--- a/artificial_u/api/routers/courses.py
+++ b/artificial_u/api/routers/courses.py
@@ -223,6 +223,32 @@ async def delete_course(
     # FastAPI will handle the 204 status code automatically based on the decorator
 
 
+@router.post(
+    "/{course_id}/publish",
+    response_model=CourseResponse,
+    summary="Publish course",
+    description="Publish a course, making it visible to the public. This is a one-way action.",
+    responses={
+        404: {"description": "Course not found"},
+        403: {"description": "Forbidden - user doesn't own this course"},
+        400: {"description": "Course is already published"},
+        500: {"description": "Internal server error during publishing"},
+    },
+    dependencies=[require_role("creator")],
+)
+async def publish_course(
+    course_id: int = Path(..., description="The ID of the course to publish"),
+    course_service: CourseApiService = Depends(get_course_api_service),
+    student: Student = Depends(ensure_student),
+):
+    """
+    Publish a course by changing its status from 'hidden' to 'published'.
+    This is a one-way action - courses cannot be unpublished.
+    Only the course creator or an admin can publish a course.
+    """
+    return course_service.publish_course(course_id, student.id, student.role)
+
+
 @router.get(
     "/{course_id}/professor",
     response_model=CourseProfessorBrief,

--- a/artificial_u/api/services/course_service.py
+++ b/artificial_u/api/services/course_service.py
@@ -464,6 +464,54 @@ class CourseApiService(BaseApiService[CoreCourse, CourseResponse, CoursesListRes
         except Exception as e:
             self._handle_general_error("delete course", e)
 
+    def publish_course(self, course_id: int, student_id: int, role: str) -> CourseResponse:
+        """
+        Publish a course by changing its status from 'hidden' to 'published'.
+        This is a one-way action - courses cannot be unpublished.
+
+        Args:
+            course_id: ID of the course to publish
+            student_id: ID of the requesting student
+            role: Role of the requesting student
+
+        Raises:
+            HTTPException: 403 if user doesn't own the course (unless admin)
+            HTTPException: 404 if course not found
+            HTTPException: 400 if course is already published
+        """
+        try:
+            # First, get the course to check ownership and current status
+            course_model = self.core_service.get_course(course_id)
+
+            # Verify ownership (admins can publish any course, creators only their own)
+            from artificial_u.api.security.auth0 import verify_asset_ownership
+
+            verify_asset_ownership(student_id, course_model.created_by, role, "course")
+
+            # Check if already published
+            if course_model.status == "published":
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Course {course_id} is already published.",
+                )
+
+            # Update the course status to published
+            updated_course_model = self.core_service.update_course(
+                course_id, {"status": "published"}
+            )
+
+            # Convert the returned CourseModel to the API response model
+            return self._build_course_response(updated_course_model)
+        except CourseNotFoundError:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Course with ID {course_id} not found.",
+            )
+        except DatabaseError as e:
+            self._handle_database_error("publish course", e)
+        except Exception as e:
+            self._handle_general_error("publish course", e)
+
     def get_course_professor(self, course_id: int) -> ProfessorBrief:
         """
         Get the professor who teaches a course.

--- a/artificial_u/models/core.py
+++ b/artificial_u/models/core.py
@@ -3,7 +3,7 @@ Core data models for the ArtificialU system.
 """
 
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -196,6 +196,7 @@ class Course(BaseModel):
     level: Optional[str] = None
     total_weeks: int = 12
     language: Optional[str] = None
+    status: Literal["hidden", "published"] = "hidden"
     department_id: Optional[int] = None
     professor_id: Optional[int] = None
     # Attribution

--- a/artificial_u/models/database.py
+++ b/artificial_u/models/database.py
@@ -37,6 +37,7 @@ class CourseModel(Base):
     level = Column(String, nullable=True)
     total_weeks = Column(Integer, nullable=True, default=12)
     language = Column(String, nullable=True)
+    status = Column(String, nullable=False, default="hidden")
     department_id = Column(Integer, ForeignKey("departments.id"), nullable=True)
     professor_id = Column(Integer, ForeignKey("professors.id"), nullable=True)
     # New attribution fields

--- a/web/src/api/services/course-service.ts
+++ b/web/src/api/services/course-service.ts
@@ -64,6 +64,10 @@ export const courseService = {
     return httpClient.delete(ENDPOINTS.courses.detail(courseId))
   },
 
+  publishCourse: (courseId: number): Promise<Course> => {
+    return httpClient.post<Course>(`${ENDPOINTS.courses.detail(courseId)}/publish`, {})
+  },
+
   getCourseProfessor: (courseId: number): Promise<ProfessorBrief> => {
     return httpClient.get<ProfessorBrief>(ENDPOINTS.courses.professor(courseId))
   },

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -27,6 +27,8 @@ export interface HealthCheckResponse {
 }
 
 // Course types
+export type CourseStatus = 'hidden' | 'published'
+
 export interface Course {
   id: number
   code: string
@@ -38,6 +40,7 @@ export interface Course {
   description: string
   lectures_per_week: number
   total_weeks: number
+  status: CourseStatus
   created_by?: number | null
   created_with?: string | null
   created_at?: string | null
@@ -100,6 +103,7 @@ export interface CourseUpdate {
   description?: string
   lectures_per_week?: number
   total_weeks?: number
+  status?: CourseStatus
 }
 
 export interface CoursesListResponse {

--- a/web/src/pages/CourseDetail.tsx
+++ b/web/src/pages/CourseDetail.tsx
@@ -15,7 +15,7 @@ import { useAuth } from '../auth/AuthProvider'
 import { RequireRole } from '../auth/RequireRole'
 import CourseForm from '../components/courses/CourseForm.jsx'
 import type { CourseFormData } from '../components/courses/types.jsx'
-import { Alert, Button, MetadataInfo } from '../components/ui'
+import { Alert, Button, MagicButton, MetadataInfo } from '../components/ui'
 import { useAudioPlayer } from '../utils/audio-player-context.jsx'
 
 // Department Info Component
@@ -248,6 +248,7 @@ const CourseDetail: Component = () => {
   const [isExporting, setIsExporting] = createSignal(false)
   const [exportJobId, setExportJobId] = createSignal<number | null>(null)
   const [exportMessage, setExportMessage] = createSignal('')
+  const [isPublishing, setIsPublishing] = createSignal(false)
 
   // Check if courseId is a valid number before creating resources
   const isValidId = !Number.isNaN(courseId)
@@ -356,6 +357,26 @@ const CourseDetail: Component = () => {
       })
   }
 
+  // Handler for publishing a course
+  const handlePublishCourse = () => {
+    if (!isValidId) return
+
+    setIsPublishing(true)
+    setError('')
+
+    void courseService
+      .publishCourse(courseId)
+      .then(() => {
+        void refetch()
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : 'Failed to publish course')
+      })
+      .finally(() => {
+        setIsPublishing(false)
+      })
+  }
+
   return (
     <div class="container mx-auto p-6">
       <Show when={isValidId} fallback={<div class="text-parchment-100">Invalid Course ID.</div>}>
@@ -378,6 +399,17 @@ const CourseDetail: Component = () => {
                   </A>
                   <Show when={!isEditing()}>
                     <div class="flex gap-2">
+                      <Show when={auth.canModify(course().created_by) && course().status === 'hidden'}>
+                        <MagicButton
+                          variant="secondary"
+                          onClick={handlePublishCourse}
+                          disabled={isPublishing()}
+                          isLoading={isPublishing()}
+                          loadingText="Publishing..."
+                        >
+                          Publish Course
+                        </MagicButton>
+                      </Show>
                       <Show when={auth.canModify(course().created_by)}>
                         <Button variant="primary" onClick={() => setIsEditing(true)}>
                           Edit Course
@@ -469,9 +501,20 @@ const CourseDetail: Component = () => {
                     </RequireRole>
                   }
                 >
-                  <h1 class="text-3xl font-display text-parchment-100 mb-3">
-                    {course().code}: {course().title}
-                  </h1>
+                  <div class="flex items-center gap-4 mb-3">
+                    <h1 class="text-3xl font-display text-parchment-100">
+                      {course().code}: {course().title}
+                    </h1>
+                    <span
+                      class={`px-3 py-1 text-sm font-medium rounded-full ${
+                        course().status === 'published'
+                          ? 'bg-green-500/20 text-green-300 border border-green-400/30'
+                          : 'bg-amber-500/20 text-amber-300 border border-amber-400/30'
+                      }`}
+                    >
+                      {course().status === 'published' ? '✓ Published' : '● Hidden'}
+                    </span>
+                  </div>
                   <p class="text-base italic text-parchment-200 mb-6 font-serif">
                     {course().description}
                   </p>

--- a/web/src/pages/Courses.tsx
+++ b/web/src/pages/Courses.tsx
@@ -354,6 +354,9 @@ const Courses: Component = () => {
                   <SortableHeader field="code" label={t().courses.code} />
                   <SortableHeader field="title" label={t().courses.courseTitle} />
                   <th class="py-3 px-4 align-middle text-left font-display text-parchment-200">
+                    Status
+                  </th>
+                  <th class="py-3 px-4 align-middle text-left font-display text-parchment-200">
                     {t().courses.teacher}
                   </th>
                   <th class="py-3 px-4 align-middle text-left font-display text-parchment-200">
@@ -380,6 +383,17 @@ const Courses: Component = () => {
                         >
                           {course.title}
                         </A>
+                      </td>
+                      <td class="py-3 px-4 align-middle">
+                        <span
+                          class={`px-2 py-1 text-xs font-medium rounded-full ${
+                            course.status === 'published'
+                              ? 'bg-green-500/20 text-green-300 border border-green-400/30'
+                              : 'bg-amber-500/20 text-amber-300 border border-amber-400/30'
+                          }`}
+                        >
+                          {course.status === 'published' ? '✓ Published' : '● Hidden'}
+                        </span>
                       </td>
                       <td class="py-3 px-4 align-middle text-parchment-100">
                         {getProfessorName(course)}
@@ -410,12 +424,23 @@ const Courses: Component = () => {
                   <div class="flex flex-col gap-4">
                     <div class="flex items-start justify-between gap-4">
                       <div class="flex-1">
-                        <p class="text-xs font-serif uppercase tracking-wide text-parchment-400">
-                          {course.code}
-                        </p>
+                        <div class="flex items-center gap-2 mb-1">
+                          <p class="text-xs font-serif uppercase tracking-wide text-parchment-400">
+                            {course.code}
+                          </p>
+                          <span
+                            class={`px-2 py-0.5 text-xs font-medium rounded-full ${
+                              course.status === 'published'
+                                ? 'bg-green-500/20 text-green-300 border border-green-400/30'
+                                : 'bg-amber-500/20 text-amber-300 border border-amber-400/30'
+                            }`}
+                          >
+                            {course.status === 'published' ? '✓' : '●'}
+                          </span>
+                        </div>
                         <A
                           href={`/courses/${String(course.id)}`}
-                          class="mt-1 block text-lg font-display text-parchment-100 leading-tight hover:text-mystic-300 transition-colors"
+                          class="block text-lg font-display text-parchment-100 leading-tight hover:text-mystic-300 transition-colors"
                         >
                           {course.title}
                         </A>


### PR DESCRIPTION
Introduces a new status field to courses that supports two states:
- hidden: default for newly created courses (private)
- published: courses made publicly visible (one-way action)

Backend changes:
- Add status column to courses table with migration
- Update SQLAlchemy and Pydantic models with Literal type
- Add POST /courses/{id}/publish endpoint for publishing
- Implement publish_course service method with ownership validation
- Existing courses set to 'published' in migration

Frontend changes:
- Add CourseStatus type and update Course interface
- Implement publishCourse API method
- Add status badge indicators in course list and detail views
- Create animated publish button using MagicButton component
- Display status prominently with color-coded badges (green for published, amber for hidden)

Publishing is a one-way action - courses cannot be unpublished.