### PR TITLE
Save and restore audio playback progress

### DIFF
--- a/web/src/utils/audio-player-context.tsx
+++ b/web/src/utils/audio-player-context.tsx
@@ -1,5 +1,5 @@
 import type { Accessor, ParentComponent } from 'solid-js'
-import { createContext, createEffect, createSignal, useContext } from 'solid-js'
+import { createContext, createEffect, createSignal, onCleanup, useContext } from 'solid-js'
 
 export interface AudioTrack {
   url: string
@@ -86,14 +86,13 @@ export const AudioPlayerProvider: ParentComponent = (props) => {
       currentTrack: currentTrack(),
       duration: duration(),
       volume: volume(),
-      // Don't save currentTime here - it updates too frequently during playback
+      // Don't save currentTime here - it's saved periodically during playback
       currentTime: 0,
     }
     saveState(state)
   })
 
-  // Save currentTime to localStorage only when pausing or stopping
-  // (not during playback to avoid excessive writes)
+  // Save currentTime to localStorage (called on pause/stop and periodically during playback)
   const saveCurrentTime = () => {
     const state: Partial<AudioPlayerState> = {
       currentTrack: currentTrack(),
@@ -103,6 +102,19 @@ export const AudioPlayerProvider: ParentComponent = (props) => {
     }
     saveState(state)
   }
+
+  // Periodically save progress during playback (every 3 seconds)
+  createEffect(() => {
+    if (isPlaying()) {
+      const intervalId = setInterval(() => {
+        saveCurrentTime()
+      }, 3000) // Save every 3 seconds
+
+      onCleanup(() => {
+        clearInterval(intervalId)
+      })
+    }
+  })
 
   const playTrack = (track: AudioTrack) => {
     setCurrentTrack(track)


### PR DESCRIPTION
Implement periodic saving of audio playback position every 3 seconds while playing. This ensures users can refresh the page or leave and return without losing their place in a lecture. Progress is saved to localStorage automatically during playback, in addition to the existing manual save on pause/stop.

- Added periodic save effect that triggers every 3 seconds during playback
- Properly cleans up interval when playback stops or component unmounts
- New tracks still start from position 0 as expected
- Updated comments to reflect the new automatic persistence behavior