### PR TITLE
Fix professor voice update not applying to audio

### DIFF
--- a/artificial_u/models/repositories/lecture.py
+++ b/artificial_u/models/repositories/lecture.py
@@ -550,6 +550,7 @@ class LectureRepository(BaseRepository):
                 "transcript_url",
                 "course_id",
                 "topic_id",
+                "voice_id",
                 "created_by",
                 "created_with",
             }
@@ -574,6 +575,7 @@ class LectureRepository(BaseRepository):
                 transcript_url=db_lecture.transcript_url,
                 course_id=db_lecture.course_id,
                 topic_id=db_lecture.topic_id,
+                voice_id=db_lecture.voice_id,
                 word_count=db_lecture.word_count,
                 created_by=db_lecture.created_by,
                 created_with=db_lecture.created_with,


### PR DESCRIPTION
…ds method

When regenerating lecture audio with an updated professor voice, the voice_id field was being silently ignored during the update. This caused lectures to retain their old voice_id even after audio regeneration.

The update_fields method had an allowed_fields whitelist that did not include 'voice_id', and the return statement also omitted it. This fix:

- Adds 'voice_id' to the allowed_fields set
- Includes voice_id in the returned Lecture model

Now when audio is regenerated with a professor's updated voice, the lecture record correctly stores the new voice_id.