### PR TITLE
Voice creation

### DIFF
--- a/alembic/versions/ce5872a4b916_add_cloned_from_to_voices.py
+++ b/alembic/versions/ce5872a4b916_add_cloned_from_to_voices.py
@@ -1,0 +1,31 @@
+"""add cloned_from to voices
+
+Revision ID: ce5872a4b916
+Revises: f5a6b7c8d9e0
+Create Date: 2026-04-12 22:42:06.349378
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "ce5872a4b916"
+down_revision = "f5a6b7c8d9e0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("voices", sa.Column("cloned_from", sa.Integer(), nullable=True))
+    op.create_foreign_key(
+        "fk_voices_cloned_from", "voices", "voices", ["cloned_from"], ["id"], ondelete="SET NULL"
+    )
+    op.create_index("idx_voices_cloned_from", "voices", ["cloned_from"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_voices_cloned_from", table_name="voices")
+    op.drop_constraint("fk_voices_cloned_from", "voices", type_="foreignkey")
+    op.drop_column("voices", "cloned_from")

--- a/artificial_u/api/models/voice.py
+++ b/artificial_u/api/models/voice.py
@@ -31,6 +31,9 @@ class VoiceBase(BaseModel):
     verified_languages: List[Dict[str, Any]] = Field(
         default_factory=list, description="Verified languages for the voice"
     )
+    cloned_from: Optional[int] = Field(
+        None, description="ID of the source voice this was cloned from, if any"
+    )
 
 
 class VoiceResponse(VoiceBase):
@@ -49,6 +52,41 @@ class VoiceListResponse(BaseModel):
     page: int = Field(..., description="Current page number")
     size: int = Field(..., description="Number of items per page")
     pages: int = Field(..., description="Total number of pages")
+
+
+class VoiceDesignPreview(BaseModel):
+    """A single audio preview returned by the ElevenLabs Voice Design API."""
+
+    generated_voice_id: str = Field(
+        ..., description="Temporary voice ID; valid only until saved to the library"
+    )
+    audio_sample: str = Field(..., description="Base64-encoded MP3 audio sample")
+    media_type: str = Field("audio/mpeg", description="MIME type of the audio sample")
+    duration_secs: Optional[float] = Field(None, description="Duration of the audio sample")
+    voice_description: str = Field(..., description="The Voice Design prompt that was used")
+
+
+class VoiceDesignPreviewsResponse(BaseModel):
+    """Response containing multiple Voice Design previews for a professor."""
+
+    previews: List[VoiceDesignPreview]
+
+
+class VoiceDesignSaveRequest(BaseModel):
+    """Request to save a selected Voice Design preview and assign it to a professor."""
+
+    professor_id: int = Field(..., description="Database ID of the professor")
+    generated_voice_id: str = Field(..., description="Temporary ID from the Voice Design preview")
+    voice_name: str = Field(..., description="Name to give the saved voice in the library")
+    voice_description: str = Field(
+        ..., description="The Voice Design prompt (stored as the voice description)"
+    )
+
+
+class VoiceCloneToMistralRequest(BaseModel):
+    """Request to clone a professor's current ElevenLabs voice into Mistral."""
+
+    professor_id: int = Field(..., description="Database ID of the professor")
 
 
 class ManualVoiceAssignmentRequest(BaseModel):

--- a/artificial_u/api/routers/voices.py
+++ b/artificial_u/api/routers/voices.py
@@ -13,6 +13,9 @@ from pydantic import BaseModel, Field
 from artificial_u.api.dependencies import get_voice_service
 from artificial_u.api.models.voice import (
     ManualVoiceAssignmentRequest,
+    VoiceCloneToMistralRequest,
+    VoiceDesignPreviewsResponse,
+    VoiceDesignSaveRequest,
     VoiceListResponse,
     VoiceResponse,
 )
@@ -66,6 +69,94 @@ async def manual_assign_voice(
         # converting it to index.html (CloudFront converts 404/403 to 200+index.html for SPA)
         raise HTTPException(status_code=400, detail=str(e))
     return
+
+
+# ---------------------------------------------------------------------------
+# Voice Design (ElevenLabs text-to-voice)
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/design/previews",
+    response_model=VoiceDesignPreviewsResponse,
+    dependencies=[Depends(require_auth)],
+)
+async def generate_voice_design_previews(
+    professor_id: int = Body(..., embed=True),
+    voice_service: VoiceService = Depends(get_voice_service),
+):
+    """Generate Voice Design audio previews for a professor.
+
+    Builds a voice prompt from the professor's attributes and calls the
+    ElevenLabs Voice Design API.  Returns up to 3 short audio previews
+    (base64 MP3) along with their temporary ``generated_voice_id`` values.
+
+    The client should present the previews to the user and call
+    ``POST /design/save`` with the chosen ``generated_voice_id``.
+    """
+    try:
+        previews = voice_service.generate_voice_design_previews(professor_id)
+        return VoiceDesignPreviewsResponse(previews=previews)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error("Voice Design preview generation failed: %s", e)
+        raise HTTPException(status_code=502, detail=f"Voice Design API error: {e}")
+
+
+@router.post(
+    "/design/save",
+    response_model=VoiceResponse,
+    dependencies=[Depends(require_auth)],
+)
+async def save_voice_design(
+    request: VoiceDesignSaveRequest = Body(...),
+    voice_service: VoiceService = Depends(get_voice_service),
+):
+    """Save a selected Voice Design preview to the ElevenLabs library.
+
+    Permanently saves the chosen preview as a named voice in the ElevenLabs
+    voice library, creates a ``Voice`` record in the database, and assigns
+    the voice to the professor.
+    """
+    try:
+        voice = voice_service.save_designed_voice(
+            professor_id=request.professor_id,
+            generated_voice_id=request.generated_voice_id,
+            voice_name=request.voice_name,
+            voice_description=request.voice_description,
+        )
+        return VoiceResponse(**voice)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error("Failed to save designed voice: %s", e)
+        raise HTTPException(status_code=502, detail=f"Failed to save voice: {e}")
+
+
+@router.post(
+    "/clone-to-mistral",
+    response_model=VoiceResponse,
+    dependencies=[Depends(require_auth)],
+)
+async def clone_voice_to_mistral(
+    request: VoiceCloneToMistralRequest = Body(...),
+    voice_service: VoiceService = Depends(get_voice_service),
+):
+    """Clone a professor's current ElevenLabs voice into the Mistral voice library.
+
+    Downloads the ElevenLabs voice preview audio and submits it to Mistral as a
+    voice clone sample.  The professor is re-associated with the resulting Mistral
+    voice; the original ElevenLabs voice record is left intact.
+    """
+    try:
+        voice = voice_service.clone_elevenlabs_voice_to_mistral(request.professor_id)
+        return VoiceResponse(**voice)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error("Failed to clone voice to Mistral: %s", e)
+        raise HTTPException(status_code=502, detail=f"Voice cloning failed: {e}")
 
 
 @router.get("/", response_model=VoiceListResponse)

--- a/artificial_u/integrations/elevenlabs/client.py
+++ b/artificial_u/integrations/elevenlabs/client.py
@@ -11,6 +11,7 @@ import time
 from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import MagicMock
 
+import httpx
 from elevenlabs import play
 from elevenlabs.client import ElevenLabs
 
@@ -532,6 +533,118 @@ class ElevenLabsClient:
         except Exception as e:
             self.logger.error(f"Error retrieving user info: {e}")
             return {}
+
+    # ---------------------------------------------------------------------------
+    # Voice Design (text-to-voice) API
+    # ---------------------------------------------------------------------------
+
+    # Default sample text used when generating voice previews
+    VOICE_DESIGN_PREVIEW_TEXT = (
+        "Welcome to Artificial University. "
+        "Today we will explore ideas that challenge our assumptions "
+        "and deepen our understanding of the world around us."
+    )
+
+    def generate_voice_previews(
+        self,
+        voice_description: str,
+        text: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Generate voice previews using the ElevenLabs Voice Design API.
+
+        Calls POST /v1/text-to-voice/create-previews.
+
+        Args:
+            voice_description: Prose description of the desired voice.
+            text: Optional text to synthesise in the preview.
+                  Defaults to a short academic sentence.
+
+        Returns:
+            List of preview dicts, each containing:
+            ``generated_voice_id`` (str), ``audio_sample`` (base64 str),
+            ``media_type`` (str), ``duration_secs`` (float).
+        """
+        url = f"{self.BASE_URL}/text-to-voice/create-previews"
+        payload: Dict[str, Any] = {
+            "voice_description": voice_description,
+            "text": text or self.VOICE_DESIGN_PREVIEW_TEXT,
+            # Recommended model for voice design
+            "model_id": "eleven_multilingual_ttv_v2",
+        }
+
+        try:
+            with httpx.Client(timeout=90) as http:
+                resp = http.post(url, json=payload, headers=self.headers)
+                resp.raise_for_status()
+                data = resp.json()
+            raw_previews = data.get("previews", [])
+            self.logger.info("Voice Design: received %d preview(s)", len(raw_previews))
+            # Normalise field name: ElevenLabs returns audio_base_64; we expose audio_sample
+            previews = []
+            for p in raw_previews:
+                preview = dict(p)
+                if "audio_base_64" in preview and "audio_sample" not in preview:
+                    preview["audio_sample"] = preview.pop("audio_base_64")
+                previews.append(preview)
+            return previews
+        except httpx.HTTPStatusError as e:
+            self.logger.error(
+                "Voice Design preview request failed (%s): %s",
+                e.response.status_code,
+                e.response.text,
+            )
+            raise
+        except Exception as e:
+            self.logger.error("Voice Design preview generation failed: %s", e)
+            raise
+
+    def save_voice_to_library(
+        self,
+        generated_voice_id: str,
+        voice_name: str,
+        voice_description: str,
+    ) -> str:
+        """Save a Voice Design preview to the ElevenLabs voice library.
+
+        Calls POST /v1/text-to-voice/create-voice-from-preview.
+
+        Args:
+            generated_voice_id: Temporary ID returned by ``generate_voice_previews``.
+            voice_name: Name to give the saved voice in the library.
+            voice_description: Description of the voice (stored in the library).
+
+        Returns:
+            Permanent ElevenLabs ``voice_id`` string that can be used with TTS.
+        """
+        url = f"{self.BASE_URL}/text-to-voice/create-voice-from-preview"
+        payload: Dict[str, Any] = {
+            "voice_name": voice_name,
+            "voice_description": voice_description,
+            "generated_voice_id": generated_voice_id,
+        }
+
+        try:
+            with httpx.Client(timeout=30) as http:
+                resp = http.post(url, json=payload, headers=self.headers)
+                resp.raise_for_status()
+                data = resp.json()
+            el_voice_id = data.get("voice_id")
+            if not el_voice_id:
+                raise ValueError(f"No voice_id in ElevenLabs response: {data}")
+            self.logger.info(
+                "Voice Design: saved voice '%s' → el_voice_id=%s", voice_name, el_voice_id
+            )
+            return el_voice_id
+        except httpx.HTTPStatusError as e:
+            self.logger.error(
+                "Failed to save voice to library (%s): %s",
+                e.response.status_code,
+                e.response.text,
+            )
+            raise
+        except Exception as e:
+            self.logger.error("Failed to save voice to library: %s", e)
+            raise
 
     def play_audio(self, audio_data: bytes) -> None:
         """

--- a/artificial_u/models/core.py
+++ b/artificial_u/models/core.py
@@ -117,6 +117,7 @@ class Voice(BaseModel):
     use_case: Optional[str] = None
     verified_languages: List[Dict[str, Any]] = Field(default_factory=list)
     last_updated: datetime = Field(default_factory=datetime.now)
+    cloned_from: Optional[int] = None
 
 
 class Professor(BaseModel):

--- a/artificial_u/models/database.py
+++ b/artificial_u/models/database.py
@@ -189,6 +189,7 @@ class VoiceModel(Base):
     use_case = Column(String(100), nullable=True)
     verified_languages = Column(JSONB, nullable=True)
     last_updated = Column(DateTime, nullable=False, default=datetime.now)
+    cloned_from = Column(Integer, ForeignKey("voices.id", ondelete="SET NULL"), nullable=True)
 
     professor = relationship("ProfessorModel", back_populates="voice")
 

--- a/artificial_u/models/repositories/voice.py
+++ b/artificial_u/models/repositories/voice.py
@@ -34,6 +34,7 @@ class VoiceRepository(BaseRepository):
             use_case=db_voice.use_case,
             verified_languages=db_voice.verified_languages or [],
             last_updated=db_voice.last_updated,
+            cloned_from=db_voice.cloned_from,
         )
 
     def create(self, voice: Voice) -> Voice:
@@ -57,6 +58,7 @@ class VoiceRepository(BaseRepository):
                 use_case=voice.use_case,
                 verified_languages=voice.verified_languages,
                 last_updated=datetime.now(),
+                cloned_from=voice.cloned_from,
             )
 
             session.add(db_voice)
@@ -164,6 +166,7 @@ class VoiceRepository(BaseRepository):
             db_voice.use_case = voice.use_case
             db_voice.verified_languages = voice.verified_languages
             db_voice.last_updated = datetime.now()
+            db_voice.cloned_from = voice.cloned_from
 
             session.commit()
             return voice
@@ -219,4 +222,20 @@ class VoiceRepository(BaseRepository):
             if tts_backend:
                 query = query.filter(VoiceModel.tts_backend == tts_backend)
 
+            return query.count()
+
+    def get_clones_of(self, source_voice_id: int, tts_backend: Optional[str] = None) -> List[Voice]:
+        """Return all voices that were cloned from the given source voice."""
+        with self.get_session() as session:
+            query = session.query(VoiceModel).filter(VoiceModel.cloned_from == source_voice_id)
+            if tts_backend:
+                query = query.filter(VoiceModel.tts_backend == tts_backend)
+            return [self._to_domain(v) for v in query.all()]
+
+    def count_by_name_prefix(self, prefix: str, tts_backend: Optional[str] = None) -> int:
+        """Count voices whose name starts with the given prefix (case-insensitive)."""
+        with self.get_session() as session:
+            query = session.query(VoiceModel).filter(VoiceModel.name.ilike(f"{prefix}%"))
+            if tts_backend:
+                query = query.filter(VoiceModel.tts_backend == tts_backend)
             return query.count()

--- a/artificial_u/prompts/lecture.py
+++ b/artificial_u/prompts/lecture.py
@@ -92,6 +92,9 @@ Instructions:
    - For abbreviations pronounced as individual letters, use periods between letters
      (e.g., "G.P.T.", "F.B.I.", "U.S.A.") but keep acronyms pronounced as words intact
      (e.g., "NASA", "UNICEF", "radar").
+   - For shorthand that people say as ordinary words, spell out the spoken form
+     (e.g., "Limited" instead of "Ltd", "versus" instead of "vs", "and" instead of "&")
+     rather than clipped or symbolic written abbreviations.
 
 Before writing the final lecture, outline the structure and main points of your lecture
 inside <lecture_outline></lecture_outline> tags. This will help ensure a well-organized

--- a/artificial_u/prompts/voice.py
+++ b/artificial_u/prompts/voice.py
@@ -1,0 +1,138 @@
+"""Voice design prompt builder for ElevenLabs Voice Design API.
+
+Assembles a natural-language description of a professor's voice suitable
+for submission to the ElevenLabs Voice Design (text-to-voice) API.
+
+Current approach: rule-based template from a handful of structured attributes
+(gender, accent, age) combined with a fixed "professorial" core description.
+
+Future enhancement: pass professor attributes (including personality,
+teaching_style, etc.) to a fast LLM to produce a richer, more
+individualised prompt — the function signature is already designed for this.
+"""
+
+from typing import Any, Dict, Optional, Union
+
+# ---------------------------------------------------------------------------
+# Age normalisation
+# ---------------------------------------------------------------------------
+
+# Categorical strings → prompt phrase
+_AGE_STRING_MAP: Dict[str, str] = {
+    "young": "in their late 20s",
+    "young_adult": "in their late 20s",
+    "middle_aged": "in their 40s",
+    "middle aged": "in their 40s",
+    "old": "in their 60s",
+    "elderly": "in their late 60s or 70s",
+    "senior": "in their late 60s or 70s",
+}
+
+_DEFAULT_AGE_PHRASE = "in their 40s"
+
+
+def _normalise_age(age_raw: Optional[Union[int, str]]) -> str:
+    """Map a raw age value (int or categorical string) to a prompt-friendly phrase.
+
+    The professor model stores ``age`` as an integer (e.g. ``45``). The voice
+    mapper also uses categorical strings like ``"middle_aged"``. Both forms are
+    accepted.
+    """
+    if age_raw is None:
+        return _DEFAULT_AGE_PHRASE
+
+    # Integer age → bucket
+    if isinstance(age_raw, int):
+        if age_raw < 30:
+            return "in their late 20s"
+        if age_raw < 45:
+            return "in their mid-30s to early 40s"
+        if age_raw < 58:
+            return "in their late 40s to mid-50s"
+        if age_raw < 70:
+            return "in their 60s"
+        return "in their 70s"
+
+    # String (categorical or numeric string)
+    normalised = str(age_raw).strip().lower()
+    if normalised.isdigit():
+        return _normalise_age(int(normalised))
+    return _AGE_STRING_MAP.get(normalised, _DEFAULT_AGE_PHRASE)
+
+
+# ---------------------------------------------------------------------------
+# Prompt composition — follows ElevenLabs prompting guide structure:
+#   Native <Language>. <Gender>, <Age range>. <Quality>.
+#   Persona: <2-5 words>. Emotion: <adjectives>.
+#   <1-2 sentences about timbre, pacing, delivery>
+# ---------------------------------------------------------------------------
+
+_QUALITY = "Studio quality."
+
+_PERSONA = "Persona: knowledgeable university professor."
+
+_EMOTION = "Emotion: calm, engaged, intellectually curious."
+
+_DELIVERY = (
+    "Measured pace with deliberate enunciation — comfortable with complex vocabulary "
+    "and nuanced ideas. Warm and authoritative without being stiff; "
+    "the voice of someone who genuinely loves their subject "
+    "and wants students to understand it deeply."
+)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def build_voice_design_prompt(professor: Dict[str, Any]) -> str:
+    """Build an ElevenLabs Voice Design prompt from professor attributes.
+
+    Follows ElevenLabs' recommended prompt structure:
+      Native <Language>. <Gender>, <Age range>. <Quality>.
+      Persona: ... Emotion: ...
+      <Timbre / pacing / delivery description>
+
+    Args:
+        professor: Dictionary of professor attributes.  Recognised keys:
+            ``gender``   – "male", "female", or any string (optional)
+            ``accent``   – e.g. "American", "British", "Norwegian" (optional)
+            ``age``      – integer (e.g. 45) or categorical string (optional)
+            Additional keys (name, personality, teaching_style, …) are
+            accepted but currently unused — reserved for the future LLM path.
+
+    Returns:
+        A prose voice-description string ready for the ElevenLabs API.
+
+    Note:
+        Future enhancement: when ``personality`` or ``teaching_style`` are
+        present, call a fast LLM (e.g. claude-haiku) to weave them into a
+        richer, more individualised prompt before the delivery sentence.
+    """
+    gender_raw = str(professor.get("gender") or "").strip().lower()
+    accent_raw = str(professor.get("accent") or "").strip()
+    age_raw = professor.get("age")
+
+    # --- Language / accent ---
+    if accent_raw:
+        # e.g. "Native English, British accent." or "Native English, Oslo accent."
+        language_line = f"Native English, {accent_raw} accent."
+    else:
+        language_line = "Native English."
+
+    # --- Gender + age ---
+    gender_desc = {"male": "Male", "female": "Female"}.get(gender_raw, "Neutral")
+    age_phrase = _normalise_age(age_raw)
+    gender_age_line = f"{gender_desc}, {age_phrase}."
+
+    return " ".join(
+        [
+            language_line,
+            gender_age_line,
+            _QUALITY,
+            _PERSONA,
+            _EMOTION,
+            _DELIVERY,
+        ]
+    )

--- a/artificial_u/services/voice_service.py
+++ b/artificial_u/services/voice_service.py
@@ -744,6 +744,238 @@ class VoiceService:
             "Assigned voice %s (backend=%s) to professor %s", external_id, tts_backend, professor_id
         )
 
+    # ---------------------------------------------------------------------------
+    # Voice Design
+    # ---------------------------------------------------------------------------
+
+    def generate_voice_design_previews(self, professor_id: int) -> List[Dict[str, Any]]:
+        """Generate ElevenLabs Voice Design previews for a professor.
+
+        Builds a voice prompt from professor attributes and calls the
+        ElevenLabs Voice Design API to generate audio previews.
+
+        Args:
+            professor_id: Database ID of the professor.
+
+        Returns:
+            List of preview dicts, each with ``generated_voice_id``,
+            ``audio_sample`` (base64), ``media_type``, ``duration_secs``,
+            and ``voice_description`` (the prompt used, needed when saving).
+        """
+        from artificial_u.prompts.voice import build_voice_design_prompt
+
+        professor = self.repository_factory.professor.get(professor_id)
+        if not professor:
+            raise ValueError(f"Professor {professor_id} not found")
+
+        prompt = build_voice_design_prompt(professor.model_dump())
+        self.logger.info(
+            "Voice Design prompt for professor %d (%s): %s",
+            professor_id,
+            professor.name,
+            prompt,
+        )
+
+        previews = self.client.generate_voice_previews(voice_description=prompt)
+
+        # Attach the prompt so the caller can pass it back when saving
+        return [{**p, "voice_description": prompt} for p in previews]
+
+    def save_designed_voice(
+        self,
+        professor_id: int,
+        generated_voice_id: str,
+        voice_name: str,
+        voice_description: str,
+    ) -> Dict[str, Any]:
+        """Save a Voice Design preview and assign the resulting voice to a professor.
+
+        Steps:
+        1. Save the preview to the ElevenLabs voice library (permanent voice_id).
+        2. Fetch full voice metadata from ElevenLabs (including preview_url).
+        3. Create/upsert a Voice record in the database.
+        4. Assign the voice to the professor.
+
+        Args:
+            professor_id: Database ID of the professor.
+            generated_voice_id: Temporary ID from ``generate_voice_design_previews``.
+            voice_name: Name to give the saved voice.
+            voice_description: The Voice Design prompt (stored as description).
+
+        Returns:
+            Saved Voice as a dict (includes the database ``id``).
+        """
+        # 1. Save to ElevenLabs library
+        el_voice_id = self.client.save_voice_to_library(
+            generated_voice_id=generated_voice_id,
+            voice_name=voice_name,
+            voice_description=voice_description,
+        )
+
+        # 2. Fetch voice metadata (best-effort; preview_url may not be available immediately)
+        voice_data = self.client.get_el_voice(el_voice_id)
+
+        # 3. Create DB record
+        voice = Voice(
+            tts_backend="elevenlabs",
+            el_voice_id=el_voice_id,
+            name=voice_name,
+            description=voice_description,
+            category="generated",
+            preview_url=voice_data.get("preview_url") if voice_data else None,
+        )
+        voice_db = self.repository_factory.voice.upsert(voice)
+
+        # 4. Assign to professor
+        self.repository_factory.professor.update_field(professor_id, voice_id=voice_db.id)
+
+        self.logger.info(
+            "Saved designed voice '%s' (el_voice_id=%s, db_id=%s) " "and assigned to professor %d",
+            voice_name,
+            el_voice_id,
+            voice_db.id,
+            professor_id,
+        )
+
+        return voice_db.model_dump()
+
+    def clone_elevenlabs_voice_to_mistral(self, professor_id: int) -> Dict[str, Any]:
+        """Clone a professor's current ElevenLabs voice into the Mistral voice library.
+
+        Downloads the ElevenLabs voice preview audio and uses it as the reference
+        sample for Mistral voice cloning.  Creates a new ``Voice`` DB record with
+        ``tts_backend="mistral"`` and re-associates the professor with that voice.
+
+        Args:
+            professor_id: Database ID of the professor.
+
+        Returns:
+            The newly created Mistral ``Voice`` record as a dict.
+
+        Raises:
+            ValueError: If the professor has no ElevenLabs voice, the voice has no
+                preview URL, or the audio download / Mistral API call fails.
+        """
+        import httpx as _httpx
+
+        from artificial_u.integrations.mistral.voice_manager import MistralVoiceManager
+
+        # --- Validate professor and current voice ---
+        professor = self.repository_factory.professor.get(professor_id)
+        if not professor:
+            raise ValueError(f"Professor {professor_id} not found")
+
+        if not professor.voice_id:
+            raise ValueError("Professor has no voice assigned")
+
+        current_voice = self.repository_factory.voice.get(professor.voice_id)
+        if not current_voice:
+            raise ValueError("Professor's voice record not found in database")
+
+        if current_voice.tts_backend != "elevenlabs":
+            raise ValueError(
+                f"Professor's current voice is not ElevenLabs "
+                f"(tts_backend={current_voice.tts_backend!r}). "
+                "Only ElevenLabs voices can be cloned to Mistral."
+            )
+
+        if not current_voice.preview_url:
+            raise ValueError(
+                "The current ElevenLabs voice has no preview URL. "
+                "Try reassigning or regenerating the voice first."
+            )
+
+        # --- Download preview audio ---
+        self.logger.info(
+            "Downloading ElevenLabs preview for voice %d (%s): %s",
+            current_voice.id,
+            current_voice.name,
+            current_voice.preview_url,
+        )
+        try:
+            with _httpx.Client(timeout=30) as http:
+                resp = http.get(current_voice.preview_url)
+                resp.raise_for_status()
+                audio_bytes = resp.content
+        except Exception as e:
+            raise ValueError(f"Failed to download voice preview audio: {e}") from e
+
+        if len(audio_bytes) < 1000:
+            raise ValueError(
+                f"Downloaded audio is too small ({len(audio_bytes)} bytes) "
+                "to use as a voice clone sample."
+            )
+
+        self.logger.info("Downloaded %d bytes of audio for Mistral cloning", len(audio_bytes))
+
+        # --- Duplicate prevention: block re-cloning the same EL voice to Mistral ---
+        existing_clones = self.repository_factory.voice.get_clones_of(
+            current_voice.id, tts_backend="mistral"
+        )
+        if existing_clones:
+            raise ValueError(
+                f"This ElevenLabs voice has already been cloned to Mistral "
+                f"(voice id={existing_clones[0].id}, name={existing_clones[0].name!r}). "
+                "Assign the professor a different ElevenLabs voice before cloning again."
+            )
+
+        # --- Build metadata ---
+        base_name = professor.name or f"Professor {professor_id}"
+        # Auto-increment suffix to avoid name collisions: "Dr. Smith", "Dr. Smith 2", ...
+        existing_count = self.repository_factory.voice.count_by_name_prefix(
+            base_name, tts_backend="mistral"
+        )
+        voice_name = base_name if existing_count == 0 else f"{base_name} {existing_count + 1}"
+
+        # Normalise gender: Mistral accepts "male" or "female"
+        gender = (current_voice.gender or getattr(professor, "gender", None) or "").lower()
+        gender = gender if gender in ("male", "female") else None
+        # Age: Mistral expects an integer; professor.age is already int
+        age = getattr(professor, "age", None)
+
+        # --- Create Mistral voice ---
+        self.logger.info("Creating Mistral clone '%s' from ElevenLabs preview", voice_name)
+        mgr = MistralVoiceManager()
+        mistral_voice = mgr.create_voice(
+            name=voice_name,
+            sample_audio_bytes=audio_bytes,
+            sample_filename="preview.mp3",
+            languages=["en"],
+            gender=gender,
+            age=age,  # int; type hint in create_voice is Optional[str] but SDK accepts int
+            tags=["professor", "academic"],
+        )
+
+        mistral_voice_id = mistral_voice.get("id")
+        if not mistral_voice_id:
+            raise ValueError(f"Mistral voice creation returned no id: {mistral_voice}")
+
+        # --- Persist DB record ---
+        voice = Voice(
+            tts_backend="mistral",
+            external_id=mistral_voice_id,
+            name=voice_name,
+            gender=gender,
+            language="en",
+            cloned_from=current_voice.id,
+        )
+        voice_db = self.repository_factory.voice.upsert(voice)
+
+        # --- Re-associate professor ---
+        self.repository_factory.professor.update_field(
+            professor_id, voice_id=voice_db.id, tts_backend="mistral"
+        )
+
+        self.logger.info(
+            "Cloned ElevenLabs voice → Mistral: '%s' (mistral_id=%s, db_id=%s) " "for professor %d",
+            voice_name,
+            mistral_voice_id,
+            voice_db.id,
+            professor_id,
+        )
+
+        return voice_db.model_dump()
+
     def list_available_voices(
         self,
         gender: Optional[str] = None,

--- a/web/src/api/config.ts
+++ b/web/src/api/config.ts
@@ -130,6 +130,9 @@ export const ENDPOINTS = {
       `/v1/voices/by_external/${encodeURIComponent(backend)}/${encodeURIComponent(externalId)}`,
     preview: '/v1/voices/preview',
     mistralCatalog: '/v1/voices/mistral/catalog',
+    designPreviews: '/v1/voices/design/previews',
+    designSave: '/v1/voices/design/save',
+    cloneToMistral: '/v1/voices/clone-to-mistral',
   },
   students: {
     me: '/v1/students/me',

--- a/web/src/api/services/voice-service.ts
+++ b/web/src/api/services/voice-service.ts
@@ -8,6 +8,9 @@ import type {
   MistralVoiceCatalog,
   PaginatedVoices,
   Voice,
+  VoiceCloneToMistralRequest,
+  VoiceDesignPreviewsResponse,
+  VoiceDesignSaveRequest,
   VoiceListParams,
   VoicePreviewRequest,
   VoicePreviewResponse,
@@ -118,4 +121,39 @@ export const listMistralCatalog = async (
  */
 export const previewVoice = async (request: VoicePreviewRequest): Promise<VoicePreviewResponse> => {
   return httpClient.post<VoicePreviewResponse>(ENDPOINTS.voices.preview, request)
+}
+
+/**
+ * Generate Voice Design previews for a professor.
+ *
+ * The backend builds a voice prompt from the professor's attributes and calls
+ * the ElevenLabs Voice Design API.  Returns up to 3 short audio previews
+ * (base64 MP3) along with their temporary generated_voice_id values.
+ */
+export const generateVoiceDesignPreviews = async (
+  professorId: number
+): Promise<VoiceDesignPreviewsResponse> => {
+  return httpClient.post<VoiceDesignPreviewsResponse>(ENDPOINTS.voices.designPreviews, {
+    professor_id: professorId,
+  })
+}
+
+/**
+ * Save a selected Voice Design preview to the ElevenLabs library.
+ *
+ * Permanently saves the chosen preview as a named voice, creates a DB record,
+ * and assigns it to the professor.  Returns the saved Voice.
+ */
+export const saveDesignedVoice = async (request: VoiceDesignSaveRequest): Promise<Voice> => {
+  return httpClient.post<Voice>(ENDPOINTS.voices.designSave, request)
+}
+
+/**
+ * Clone a professor's current ElevenLabs voice into the Mistral voice library.
+ *
+ * Downloads the ElevenLabs preview audio and submits it to Mistral as a clone
+ * sample.  The professor is re-associated with the new Mistral voice.
+ */
+export const cloneVoiceToMistral = async (request: VoiceCloneToMistralRequest): Promise<Voice> => {
+  return httpClient.post<Voice>(ENDPOINTS.voices.cloneToMistral, request)
 }

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -465,6 +465,7 @@ export interface Voice {
   verified_languages: Array<Record<string, unknown>>
   popularity_score: number | null
   last_updated: string | null
+  cloned_from: number | null
 }
 
 export interface PaginatedVoices {
@@ -506,6 +507,31 @@ export interface MistralCatalogVoice {
 export interface MistralVoiceCatalog {
   items: MistralCatalogVoice[]
   total: number
+}
+
+// Voice cloning
+export interface VoiceCloneToMistralRequest {
+  professor_id: number
+}
+
+// Voice Design (ElevenLabs text-to-voice generation)
+export interface VoiceDesignPreview {
+  generated_voice_id: string
+  audio_sample: string // base64-encoded MP3
+  media_type: string
+  duration_secs: number | null
+  voice_description: string
+}
+
+export interface VoiceDesignPreviewsResponse {
+  previews: VoiceDesignPreview[]
+}
+
+export interface VoiceDesignSaveRequest {
+  professor_id: number
+  generated_voice_id: string
+  voice_name: string
+  voice_description: string
 }
 
 // Voice preview

--- a/web/src/components/professors/ProfessorDetail.tsx
+++ b/web/src/components/professors/ProfessorDetail.tsx
@@ -1,19 +1,9 @@
 import { A, useNavigate, useParams } from '@solidjs/router'
-import {
-  type Accessor,
-  type Component,
-  createResource,
-  createSignal,
-  For,
-  type Resource,
-  type Setter,
-  Show,
-} from 'solid-js'
+import { type Component, createResource, createSignal, For, type Resource, Show } from 'solid-js'
 import { departmentService } from '../../api/services/department-service.js'
 import { professorService } from '../../api/services/professor-service.js'
-import { getVoice, manualAssignVoice } from '../../api/services/voice-service.js'
+import { getVoice } from '../../api/services/voice-service.js'
 import type {
-  LectureBrief,
   Professor,
   ProfessorCourseBrief,
   ProfessorCoursesResponse,
@@ -87,13 +77,6 @@ const backendDisplayName = (backend: string): string => {
 const VoiceProfileSection: Component<{
   professorResource: Resource<Professor | undefined>
   voiceResource: Resource<Voice | undefined>
-  voiceAssignError: Accessor<string>
-  manualElVoiceId: Accessor<string>
-  setManualElVoiceId: Setter<string>
-  isAssigningVoice: Accessor<boolean>
-  isAssigningManual: Accessor<boolean>
-  handleAssignVoice: () => Promise<void>
-  handleManualAssign: () => Promise<void>
 }> = (props) => {
   /** Optional voice attributes shown only when non-empty. */
   const optionalAttrs = (): Array<{ label: string; value: string }> => {
@@ -191,58 +174,19 @@ const VoiceProfileSection: Component<{
           </Show>
         </Show>
 
-        {/* Assign/reassign & Voice ID Override inline controls */}
-        <div class="mt-3">
-          <Show when={props.voiceAssignError()}>
-            <Alert variant="danger" class="text-sm mb-2">
-              {props.voiceAssignError()}
-            </Alert>
-          </Show>
+        {/* Link to Voice Selection page */}
+        <Show when={props.professorResource()?.id}>
           <RequireRole minRole="creator">
-            <div class="flex flex-col sm:flex-row sm:items-center sm:space-x-3 space-y-2 sm:space-y-0">
-              <MagicButton
-                variant="secondary"
-                size="sm"
-                onClick={() => void props.handleAssignVoice()}
-                disabled={props.isAssigningVoice()}
-                isLoading={props.isAssigningVoice()}
-                loadingText="Assigning..."
+            <div class="mt-3">
+              <A
+                href={`/professors/${String(props.professorResource()?.id ?? '')}/voice`}
+                class="text-sm text-accent hover:text-accent/80 underline"
               >
-                {props.professorResource()?.voice_id ? 'Reassign Voice' : 'Assign Voice'}
-              </MagicButton>
-              <div class="flex items-center space-x-2">
-                <input
-                  type="text"
-                  class="input input-bordered w-full sm:w-64"
-                  placeholder="Voice ID Override"
-                  value={props.manualElVoiceId()}
-                  onInput={(e) => props.setManualElVoiceId((e.target as HTMLInputElement).value)}
-                  aria-label="Voice ID Override"
-                />
-                <MagicButton
-                  size="sm"
-                  variant="primary"
-                  onClick={() => void props.handleManualAssign()}
-                  disabled={!props.manualElVoiceId().trim() || props.isAssigningManual()}
-                  isLoading={props.isAssigningManual()}
-                  loadingText="Overriding..."
-                >
-                  Override
-                </MagicButton>
-              </div>
+                Voice Selection &amp; Preview &rarr;
+              </A>
             </div>
-            <Show when={props.professorResource()?.id}>
-              <div class="mt-2">
-                <A
-                  href={`/professors/${String(props.professorResource()?.id ?? '')}/voice`}
-                  class="text-sm text-accent hover:text-accent/80 underline"
-                >
-                  Voice Selection &amp; Preview &rarr;
-                </A>
-              </div>
-            </Show>
           </RequireRole>
-        </div>
+        </Show>
       </div>
     </>
   )
@@ -259,12 +203,6 @@ export default function ProfessorDetail() {
   const [isGeneratingImage, setIsGeneratingImage] = createSignal(false)
   const [generationError, setGenerationError] = createSignal('')
   const [isImageLoading, setIsImageLoading] = createSignal(false)
-  const [isAssigningVoice, setIsAssigningVoice] = createSignal(false)
-  const [voiceAssignError, setVoiceAssignError] = createSignal('')
-  // Manual voice entry state
-  const [manualElVoiceId, setManualElVoiceId] = createSignal('')
-  const [isAssigningManual, setIsAssigningManual] = createSignal(false)
-
   const [professorResource, { refetch: refetchProfessor }] = createResource(
     () => {
       const id = Number.parseInt(params.id ?? '', 10)
@@ -275,7 +213,6 @@ export default function ProfessorDetail() {
     },
     async (id) => {
       setIsImageLoading(false) // Reset image loading state when professor data changes
-      setVoiceAssignError('') // Clear voice assignment error when professor data changes
       return professorService.getProfessor(id)
     }
   )
@@ -308,17 +245,6 @@ export default function ProfessorDetail() {
     async (voiceId) => {
       if (voiceId) {
         return getVoice(voiceId)
-      }
-      return undefined
-    }
-  )
-
-  // Fetch professor's lectures to detect if any existing audio has been generated
-  const [lecturesResource] = createResource(
-    () => professorResource()?.id,
-    async (professorId: number) => {
-      if (professorId) {
-        return professorService.getProfessorLectures(professorId)
       }
       return undefined
     }
@@ -393,71 +319,6 @@ export default function ProfessorDetail() {
       setGenerationError(error instanceof Error ? error.message : 'Failed to generate image')
     } finally {
       setIsGeneratingImage(false)
-    }
-  }
-
-  const handleAssignVoice = async () => {
-    setIsAssigningVoice(true)
-    setVoiceAssignError('')
-    setError('')
-
-    try {
-      const id = Number.parseInt(params.id ?? '', 10)
-      if (Number.isNaN(id)) {
-        throw new Error('Invalid professor ID')
-      }
-
-      // Phase 2: warn if reassigning and lectures already have audio
-      const hasExistingVoice = Boolean(professorResource()?.voice_id)
-      const lecturesResponse = lecturesResource()
-      const lectures: LectureBrief[] | undefined = lecturesResponse?.lectures
-      const hasAudio = Array.isArray(lectures) && lectures.some((l) => l.audio_url != null)
-      if (hasExistingVoice && hasAudio) {
-        const proceed = window.confirm(
-          'This professor already has lectures with generated audio. Reassigning the voice may make future audio sound different. Are you sure you want to continue?'
-        )
-        if (!proceed) {
-          return
-        }
-      }
-
-      await professorService.assignVoiceToProfessor(id)
-      void refetchProfessor()
-    } catch (error) {
-      setVoiceAssignError(error instanceof Error ? error.message : 'Failed to assign voice')
-    } finally {
-      setIsAssigningVoice(false)
-    }
-  }
-
-  const handleManualAssign = async () => {
-    setIsAssigningManual(true)
-    setVoiceAssignError('')
-    try {
-      const professorId = Number.parseInt(params.id ?? '', 10)
-      if (Number.isNaN(professorId)) throw new Error('Invalid professor ID')
-
-      // Warn if reassigning and there is audio
-      const hasExistingVoice = Boolean(professorResource()?.voice_id)
-      const lecturesResponse = lecturesResource()
-      const lectures: LectureBrief[] | undefined = lecturesResponse?.lectures
-      const hasAudio = Array.isArray(lectures) && lectures.some((l) => l.audio_url != null)
-      if (hasExistingVoice && hasAudio) {
-        const proceed = window.confirm(
-          'This professor already has lectures with generated audio. Reassigning the voice may make future audio sound different. Are you sure you want to continue?'
-        )
-        if (!proceed) return
-      }
-
-      const externalId = manualElVoiceId().trim()
-      if (!externalId) throw new Error('Please enter a voice ID to assign')
-      await manualAssignVoice(String(professorId), { external_id: externalId })
-      setManualElVoiceId('')
-      void refetchProfessor()
-    } catch (error) {
-      setVoiceAssignError(error instanceof Error ? error.message : 'Failed to assign voice')
-    } finally {
-      setIsAssigningManual(false)
     }
   }
 
@@ -695,13 +556,6 @@ export default function ProfessorDetail() {
                     <VoiceProfileSection
                       professorResource={professorResource}
                       voiceResource={voiceResource}
-                      voiceAssignError={voiceAssignError}
-                      manualElVoiceId={manualElVoiceId}
-                      setManualElVoiceId={setManualElVoiceId}
-                      isAssigningVoice={isAssigningVoice}
-                      isAssigningManual={isAssigningManual}
-                      handleAssignVoice={handleAssignVoice}
-                      handleManualAssign={handleManualAssign}
                     />
                   </div>
                 </div>
@@ -711,13 +565,6 @@ export default function ProfessorDetail() {
                   <VoiceProfileSection
                     professorResource={professorResource}
                     voiceResource={voiceResource}
-                    voiceAssignError={voiceAssignError}
-                    manualElVoiceId={manualElVoiceId}
-                    setManualElVoiceId={setManualElVoiceId}
-                    isAssigningVoice={isAssigningVoice}
-                    isAssigningManual={isAssigningManual}
-                    handleAssignVoice={handleAssignVoice}
-                    handleManualAssign={handleManualAssign}
                   />
                 </div>
               </div>

--- a/web/src/components/professors/ProfessorVoice.tsx
+++ b/web/src/components/professors/ProfessorVoice.tsx
@@ -1,13 +1,24 @@
 import { useParams } from '@solidjs/router'
-import { type Component, createMemo, createResource, createSignal, For, Show } from 'solid-js'
+import {
+  type Component,
+  createEffect,
+  createMemo,
+  createResource,
+  createSignal,
+  For,
+  Show,
+} from 'solid-js'
 import { professorService } from '../../api/services/professor-service.js'
 import {
+  cloneVoiceToMistral,
+  generateVoiceDesignPreviews,
   getVoice,
   listMistralCatalog,
   manualAssignVoice,
   previewVoice,
+  saveDesignedVoice,
 } from '../../api/services/voice-service.js'
-import type { MistralCatalogVoice } from '../../api/types.js'
+import type { MistralCatalogVoice, VoiceDesignPreview } from '../../api/types.js'
 import { RequireRole } from '../../auth/RequireRole'
 import { Alert, Badge, Button, LoadingSpinner } from '../ui'
 
@@ -122,7 +133,16 @@ const ProfessorVoice: Component = () => {
   )
 
   // ---- Backend selection ----
-  const [selectedBackend, setSelectedBackend] = createSignal<TtsBackendKey>('mistral')
+  // Default to the current voice's backend once it loads; fall back to 'elevenlabs'
+  const [selectedBackend, setSelectedBackend] = createSignal<TtsBackendKey>('elevenlabs')
+  let backendInitialized = false
+  createEffect(() => {
+    const voice = currentVoice()
+    if (!backendInitialized && voice) {
+      backendInitialized = true
+      setSelectedBackend(voice.tts_backend === 'mistral' ? 'mistral' : 'elevenlabs')
+    }
+  })
 
   // ---- ElevenLabs manual ID ----
   const [elVoiceId, setElVoiceId] = createSignal('')
@@ -172,6 +192,7 @@ const ProfessorVoice: Component = () => {
 
   // ---- Assignment ----
   const [isAssigning, setIsAssigning] = createSignal(false)
+  const [isReassigning, setIsReassigning] = createSignal(false)
   const [assignError, setAssignError] = createSignal('')
   const [assignSuccess, setAssignSuccess] = createSignal('')
 
@@ -224,6 +245,119 @@ const ProfessorVoice: Component = () => {
     }
   }
 
+  const handleReassignVoice = async () => {
+    const pId = professorId()
+    if (!pId) return
+    setAssignError('')
+    setAssignSuccess('')
+    setIsReassigning(true)
+    try {
+      await professorService.assignVoiceToProfessor(pId)
+      setAssignSuccess('Voice reassigned successfully.')
+      void refetchProfessor()
+    } catch (e) {
+      setAssignError(e instanceof Error ? e.message : 'Reassignment failed.')
+    } finally {
+      setIsReassigning(false)
+    }
+  }
+
+  // ---- Current Mistral voice preview ----
+  const [currentMistralPreviewUri, setCurrentMistralPreviewUri] = createSignal<string | null>(null)
+  const [isPreviewingCurrentVoice, setIsPreviewingCurrentVoice] = createSignal(false)
+
+  const handlePreviewCurrentVoice = async () => {
+    const voice = currentVoice()
+    if (!voice?.external_id) return
+    setIsPreviewingCurrentVoice(true)
+    setCurrentMistralPreviewUri(null)
+    try {
+      const resp = await previewVoice({ voice_id: voice.external_id, tts_backend: 'mistral' })
+      setCurrentMistralPreviewUri(resp.audio_data_uri)
+    } catch (e) {
+      console.error('Current voice preview failed', e)
+    } finally {
+      setIsPreviewingCurrentVoice(false)
+    }
+  }
+
+  // ---- Clone to Mistral ----
+  const [isCloningToMistral, setIsCloningToMistral] = createSignal(false)
+  const [cloneError, setCloneError] = createSignal('')
+
+  const handleCloneToMistral = async () => {
+    const pId = professorId()
+    if (!pId) return
+    setCloneError('')
+    setAssignError('')
+    setAssignSuccess('')
+    setIsCloningToMistral(true)
+    try {
+      await cloneVoiceToMistral({ professor_id: pId })
+      setAssignSuccess('Voice cloned to Mistral successfully.')
+      void refetchProfessor()
+    } catch (e) {
+      setCloneError(e instanceof Error ? e.message : 'Cloning failed.')
+    } finally {
+      setIsCloningToMistral(false)
+    }
+  }
+
+  // ---- Voice Design ----
+  const [designPreviews, setDesignPreviews] = createSignal<VoiceDesignPreview[]>([])
+  const [isGeneratingPreviews, setIsGeneratingPreviews] = createSignal(false)
+  const [designError, setDesignError] = createSignal('')
+  // Per-preview name inputs (keyed by generated_voice_id)
+  const [previewNames, setPreviewNames] = createSignal<Record<string, string>>({})
+  const [isSavingId, setIsSavingId] = createSignal<string | null>(null)
+
+  const handleGeneratePreviews = async () => {
+    const pId = professorId()
+    if (!pId) return
+    setDesignError('')
+    setDesignPreviews([])
+    setPreviewNames({})
+    setIsGeneratingPreviews(true)
+    try {
+      const result = await generateVoiceDesignPreviews(pId)
+      setDesignPreviews(result.previews)
+      // Seed default names: "Prof. Name — Voice 1", etc.
+      const profName = professor()?.name ?? 'Professor'
+      const names: Record<string, string> = {}
+      result.previews.forEach((p, i) => {
+        names[p.generated_voice_id] = `${profName} — Voice ${String(i + 1)}`
+      })
+      setPreviewNames(names)
+    } catch (e) {
+      setDesignError(e instanceof Error ? e.message : 'Failed to generate voice previews.')
+    } finally {
+      setIsGeneratingPreviews(false)
+    }
+  }
+
+  const handleSaveDesignedVoice = async (preview: VoiceDesignPreview) => {
+    const pId = professorId()
+    if (!pId) return
+    setDesignError('')
+    setIsSavingId(preview.generated_voice_id)
+    try {
+      await saveDesignedVoice({
+        professor_id: pId,
+        generated_voice_id: preview.generated_voice_id,
+        voice_name: previewNames()[preview.generated_voice_id] ?? 'Generated Voice',
+        voice_description: preview.voice_description,
+      })
+      setDesignPreviews([])
+      setPreviewNames({})
+      setAssignSuccess('New voice saved and assigned successfully.')
+      void refetchProfessor()
+    } catch (e) {
+      setDesignError(e instanceof Error ? e.message : 'Failed to save voice.')
+    } finally {
+      setIsSavingId(null)
+    }
+  }
+
   // Reset selection when backend changes
   const switchBackend = (b: TtsBackendKey) => {
     setSelectedBackend(b)
@@ -248,24 +382,54 @@ const ProfessorVoice: Component = () => {
 
       {/* Current voice summary */}
       <Show when={professor()?.voice_id}>
-        <div class="arcane-card p-4">
-          <h2 class="text-lg font-display text-parchment-100 mb-2">Current Voice</h2>
+        <div class="arcane-card p-4 space-y-3">
+          <h2 class="text-lg font-display text-parchment-100">Current Voice</h2>
           <Show when={currentVoice()} fallback={<p class="text-muted text-sm">Loading...</p>}>
             {(voice) => (
-              <div class="flex flex-wrap items-center gap-2 text-sm">
-                <Badge variant="secondary">
-                  {voice().tts_backend === 'elevenlabs' ? 'ElevenLabs' : 'Voxtral'}
-                </Badge>
-                <span class="text-foreground font-medium">
-                  {voice().name ?? voice().external_id ?? voice().el_voice_id}
-                </span>
-                <Show when={voice().gender}>
-                  <Badge variant="outline">{genderLabel(voice().gender)}</Badge>
+              <>
+                <div class="flex flex-wrap items-center gap-2 text-sm">
+                  <Badge variant="secondary">
+                    {voice().tts_backend === 'elevenlabs' ? 'ElevenLabs' : 'Voxtral'}
+                  </Badge>
+                  <span class="text-foreground font-medium">
+                    {voice().name ?? voice().external_id ?? voice().el_voice_id}
+                  </span>
+                  <Show when={voice().gender}>
+                    <Badge variant="outline">{genderLabel(voice().gender)}</Badge>
+                  </Show>
+                  <Show when={voice().descriptive}>
+                    <Badge variant="outline">{voice().descriptive}</Badge>
+                  </Show>
+                  <Show when={voice().tts_backend === 'mistral' && voice().external_id}>
+                    <button
+                      type="button"
+                      class="text-xs px-2 py-1 rounded bg-surface hover:bg-accent/20 text-accent transition-colors disabled:opacity-50"
+                      onClick={() => void handlePreviewCurrentVoice()}
+                      disabled={isPreviewingCurrentVoice()}
+                    >
+                      {isPreviewingCurrentVoice() ? '…' : '▶ Preview'}
+                    </button>
+                  </Show>
+                </div>
+                <Show when={currentMistralPreviewUri()}>
+                  <audio
+                    controls
+                    autoplay
+                    class="w-full max-w-sm"
+                    src={currentMistralPreviewUri() ?? ''}
+                    aria-label="Current voice preview"
+                  >
+                    <track
+                      kind="captions"
+                      src="data:text/vtt;charset=utf-8,WEBVTT%0A%0A"
+                      srclang="en"
+                      label="English captions"
+                      default
+                    />
+                    Your browser does not support the audio element.
+                  </audio>
                 </Show>
-                <Show when={voice().descriptive}>
-                  <Badge variant="outline">{voice().descriptive}</Badge>
-                </Show>
-              </div>
+              </>
             )}
           </Show>
         </div>
@@ -296,27 +460,190 @@ const ProfessorVoice: Component = () => {
         <div class="arcane-card p-5">
           {/* ElevenLabs: simple paste-ID form */}
           <Show when={selectedBackend() === 'elevenlabs'}>
-            <div class="space-y-4">
-              <p class="text-sm text-muted">
-                Paste an existing ElevenLabs voice ID to assign it to this professor.
-              </p>
-              <div class="flex items-center gap-3">
-                <input
-                  type="text"
-                  class="arcane-input flex-1"
-                  placeholder="e.g. pNInz6obpgDQGcFmaJgB"
-                  value={elVoiceId()}
-                  onInput={(e) => setElVoiceId((e.target as HTMLInputElement).value)}
-                  aria-label="ElevenLabs Voice ID"
-                />
+            <div class="space-y-6">
+              {/* Preview for the currently assigned ElevenLabs voice */}
+              <Show
+                when={currentVoice()?.tts_backend === 'elevenlabs' && currentVoice()?.preview_url}
+              >
+                <div class="space-y-2">
+                  <p class="text-sm font-medium text-foreground">Current voice preview</p>
+                  <audio
+                    controls
+                    class="w-full max-w-sm"
+                    aria-label="Current voice preview"
+                    src={currentVoice()?.preview_url ?? ''}
+                  >
+                    <track
+                      kind="captions"
+                      src="data:text/vtt;charset=utf-8,WEBVTT%0A%0A"
+                      srclang="en"
+                      label="English captions"
+                      default
+                    />
+                    Your browser does not support the audio element.
+                  </audio>
+                </div>
+              </Show>
+
+              <div class="space-y-4">
+                <p class="text-sm text-muted">
+                  Paste an existing ElevenLabs voice ID to assign it to this professor.
+                </p>
+                <div class="flex items-center gap-3">
+                  <input
+                    type="text"
+                    class="arcane-input flex-1"
+                    placeholder="e.g. pNInz6obpgDQGcFmaJgB"
+                    value={elVoiceId()}
+                    onInput={(e) => setElVoiceId((e.target as HTMLInputElement).value)}
+                    aria-label="ElevenLabs Voice ID"
+                  />
+                  <Button
+                    variant="primary"
+                    onClick={() => void handleAssign()}
+                    disabled={!elVoiceId().trim() || isAssigning()}
+                  >
+                    {isAssigning() ? 'Assigning...' : 'Assign'}
+                  </Button>
+                </div>
+              </div>
+
+              <div class="border-t border-parchment-800/30 pt-5 space-y-3">
+                <div>
+                  <p class="text-sm font-medium text-foreground">Try another voice</p>
+                  <p class="text-xs text-muted mt-0.5">
+                    Automatically pick a matching ElevenLabs voice based on this professor's
+                    attributes (gender, accent, age).
+                  </p>
+                </div>
                 <Button
-                  variant="primary"
-                  onClick={() => void handleAssign()}
-                  disabled={!elVoiceId().trim() || isAssigning()}
+                  variant="secondary"
+                  onClick={() => void handleReassignVoice()}
+                  disabled={isReassigning()}
                 >
-                  {isAssigning() ? 'Assigning...' : 'Assign'}
+                  {isReassigning() ? 'Reassigning...' : 'Reassign Voice'}
                 </Button>
               </div>
+
+              {/* Voice Design — experimental */}
+              <div class="border-t border-parchment-800/30 pt-5 space-y-4">
+                <div class="flex items-start justify-between gap-3">
+                  <div>
+                    <p class="text-sm font-medium text-foreground">
+                      Generate a New Voice{' '}
+                      <span class="text-xs font-normal text-accent ml-1">[Experimental]</span>
+                    </p>
+                    <p class="text-xs text-muted mt-0.5">
+                      Create a custom ElevenLabs voice from this professor's attributes. Listen to
+                      the options and choose your favourite.
+                    </p>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    onClick={() => void handleGeneratePreviews()}
+                    disabled={isGeneratingPreviews()}
+                    class="shrink-0"
+                  >
+                    {isGeneratingPreviews() ? (
+                      <span class="flex items-center gap-2">
+                        <LoadingSpinner size="sm" />
+                        Generating…
+                      </span>
+                    ) : (
+                      'Generate Options'
+                    )}
+                  </Button>
+                </div>
+
+                <Show when={designError()}>
+                  <Alert variant="danger">{designError()}</Alert>
+                </Show>
+
+                <Show when={designPreviews().length > 0}>
+                  <div class="space-y-3">
+                    <For each={designPreviews()}>
+                      {(preview, i) => (
+                        <div class="arcane-card-sm p-4 space-y-3">
+                          <div class="flex items-center justify-between gap-3">
+                            <input
+                              type="text"
+                              class="arcane-input flex-1 text-sm"
+                              value={
+                                previewNames()[preview.generated_voice_id] ??
+                                `Voice ${String(i() + 1)}`
+                              }
+                              onInput={(e) =>
+                                setPreviewNames((prev) => ({
+                                  ...prev,
+                                  [preview.generated_voice_id]: (e.target as HTMLInputElement)
+                                    .value,
+                                }))
+                              }
+                              aria-label={`Name for voice option ${String(i() + 1)}`}
+                            />
+                            <Button
+                              variant="primary"
+                              size="sm"
+                              onClick={() => void handleSaveDesignedVoice(preview)}
+                              disabled={isSavingId() !== null}
+                              class="shrink-0"
+                            >
+                              {isSavingId() === preview.generated_voice_id
+                                ? 'Saving…'
+                                : 'Use This Voice'}
+                            </Button>
+                          </div>
+                          <audio
+                            controls
+                            class="w-full max-w-md"
+                            src={`data:${preview.media_type};base64,${preview.audio_sample}`}
+                            aria-label={`Preview for voice option ${String(i() + 1)}`}
+                          >
+                            <track
+                              kind="captions"
+                              src="data:text/vtt;charset=utf-8,WEBVTT%0A%0A"
+                              srclang="en"
+                              label="English captions"
+                              default
+                            />
+                            Your browser does not support the audio element.
+                          </audio>
+                        </div>
+                      )}
+                    </For>
+                  </div>
+                </Show>
+              </div>
+
+              {/* Clone to Mistral */}
+              <Show
+                when={currentVoice()?.tts_backend === 'elevenlabs' && currentVoice()?.preview_url}
+              >
+                <div class="border-t border-parchment-800/30 pt-5 flex flex-col gap-2">
+                  <div class="flex items-start justify-between gap-3">
+                    <div>
+                      <p class="text-sm font-medium text-foreground">Clone to Mistral</p>
+                      <p class="text-xs text-muted mt-0.5">
+                        Clone this voice into your Mistral library and switch the professor to
+                        Voxtral TTS.
+                      </p>
+                    </div>
+                    <Button
+                      variant="secondary"
+                      onClick={() => void handleCloneToMistral()}
+                      disabled={isCloningToMistral()}
+                      class="shrink-0"
+                    >
+                      {isCloningToMistral() ? 'Cloning…' : 'Clone to Mistral'}
+                    </Button>
+                  </div>
+                  <Show when={cloneError()}>
+                    <Alert variant="danger" class="text-sm">
+                      {cloneError()}
+                    </Alert>
+                  </Show>
+                </div>
+              </Show>
             </div>
           </Show>
 

--- a/web/src/pages/LectureDetail.tsx
+++ b/web/src/pages/LectureDetail.tsx
@@ -44,16 +44,16 @@ const LectureDetailView: Component<{
 
   return (
     <div class="arcane-card">
-      <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between mb-6">
-        <div class="space-y-1 flex-1 min-w-0">
-          <h1 class="text-3xl font-display text-parchment-100 break-words">
+      <div class="mb-6 flex flex-col gap-4">
+        <div class="min-w-0 w-full space-y-1">
+          <h1 class="font-display text-3xl break-words text-parchment-100">
             {props.lecture.title}
           </h1>
           <p class="text-parchment-300">
             {t().lectureDetail.revision} {props.lecture.revision}
           </p>
         </div>
-        <div class="flex flex-wrap items-center gap-2 md:justify-end shrink-0">
+        <div class="flex w-full shrink-0 flex-wrap items-center gap-2 justify-end">
           {/* Transcript button at top */}
           <Show when={props.lecture.transcript_url}>
             <a


### PR DESCRIPTION
This pull request introduces support for ElevenLabs Voice Design (text-to-voice) workflows, including generating, saving, and cloning AI-generated professor voices. It also enhances the data model to track voice cloning lineage and adds new endpoints and internal logic for these features.

Key changes include:

**Voice Design API integration and endpoints:**

* Added new API endpoints to generate ElevenLabs Voice Design audio previews, save selected previews as permanent voices, and clone voices into the Mistral backend (`/design/previews`, `/design/save`, `/clone-to-mistral`). These endpoints use new request/response models and are documented in `artificial_u/api/routers/voices.py`. [[1]](diffhunk://#diff-ea9f08698a63b3c71e31735aea34db58b1c70baa36a7e2edb401223f8eefa257R74-R161) [[2]](diffhunk://#diff-ea9f08698a63b3c71e31735aea34db58b1c70baa36a7e2edb401223f8eefa257R16-R18) [[3]](diffhunk://#diff-2ef1be6210ad28a71defa2a256630b2c3f4ed77317537f91aed27ec7a6f8823fR57-R91)
* Implemented ElevenLabs Voice Design client methods to generate voice previews and save voices to the ElevenLabs library, handling API requests, responses, and error cases (`artificial_u/integrations/elevenlabs/client.py`).
* Added a prompt builder module to generate natural-language voice descriptions for the Voice Design API, based on professor attributes (`artificial_u/prompts/voice.py`).

**Voice cloning lineage and data model updates:**

* Added a `cloned_from` field to the `voices` table (with migration), SQLAlchemy model, and all relevant Pydantic models to track the source of cloned voices. [[1]](diffhunk://#diff-354fe2cd17073a9c3676b1ca781c19b9dec3afc360db6325847405ff943edf9cR1-R31) [[2]](diffhunk://#diff-177cff92b3693efde4e2da322e8931bffea0b172e4c963bea74609a44b860fc7R192) [[3]](diffhunk://#diff-19d54d117585e2bbfa1c92eea6819afa630b144154c4e24490efba411729159cR120) [[4]](diffhunk://#diff-2ef1be6210ad28a71defa2a256630b2c3f4ed77317537f91aed27ec7a6f8823fR34-R36)
* Updated the repository to support `cloned_from` for create/update operations and to provide queries for retrieving clones and counting voices by name prefix. [[1]](diffhunk://#diff-7199660fb0596d2c9b10cf83a06c4b4abcd5cf0577106ef86981fbd2b6325692R37) [[2]](diffhunk://#diff-7199660fb0596d2c9b10cf83a06c4b4abcd5cf0577106ef86981fbd2b6325692R61) [[3]](diffhunk://#diff-7199660fb0596d2c9b10cf83a06c4b4abcd5cf0577106ef86981fbd2b6325692R169) [[4]](diffhunk://#diff-7199660fb0596d2c9b10cf83a06c4b4abcd5cf0577106ef86981fbd2b6325692R226-R241)

**Prompt and documentation improvements:**

* Improved lecture prompt instructions for abbreviation handling in `artificial_u/prompts/lecture.py`.

These changes enable richer and more flexible voice workflows, including automated voice creation and tracking of voice derivations.

---

**Voice Design API integration:**
- Added endpoints for generating, saving, and cloning ElevenLabs-designed voices, with new request/response models and error handling (`artificial_u/api/routers/voices.py`, `artificial_u/api/models/voice.py`). [[1]](diffhunk://#diff-ea9f08698a63b3c71e31735aea34db58b1c70baa36a7e2edb401223f8eefa257R74-R161) [[2]](diffhunk://#diff-ea9f08698a63b3c71e31735aea34db58b1c70baa36a7e2edb401223f8eefa257R16-R18) [[3]](diffhunk://#diff-2ef1be6210ad28a71defa2a256630b2c3f4ed77317537f91aed27ec7a6f8823fR57-R91)
- Implemented ElevenLabs client methods for generating previews and saving voices, including normalization of API responses (`artificial_u/integrations/elevenlabs/client.py`).
- Added a rule-based prompt builder for generating voice descriptions for the ElevenLabs API (`artificial_u/prompts/voice.py`).

**Data model and repository enhancements:**
- Added `cloned_from` field to the database schema, SQLAlchemy, and Pydantic models to track voice cloning lineage, with migration script (`alembic/versions/ce5872a4b916_add_cloned_from_to_voices.py`, `artificial_u/models/core.py`, `artificial_u/models/database.py`, `artificial_u/api/models/voice.py`). [[1]](diffhunk://#diff-354fe2cd17073a9c3676b1ca781c19b9dec3afc360db6325847405ff943edf9cR1-R31) [[2]](diffhunk://#diff-177cff92b3693efde4e2da322e8931bffea0b172e4c963bea74609a44b860fc7R192) [[3]](diffhunk://#diff-19d54d117585e2bbfa1c92eea6819afa630b144154c4e24490efba411729159cR120) [[4]](diffhunk://#diff-2ef1be6210ad28a71defa2a256630b2c3f4ed77317537f91aed27ec7a6f8823fR34-R36)
- Updated repository logic to support `cloned_from` in create/update operations and added methods to retrieve clones and count voices by prefix (`artificial_u/models/repositories/voice.py`). [[1]](diffhunk://#diff-7199660fb0596d2c9b10cf83a06c4b4abcd5cf0577106ef86981fbd2b6325692R37) [[2]](diffhunk://#diff-7199660fb0596d2c9b10cf83a06c4b4abcd5cf0577106ef86981fbd2b6325692R61) [[3]](diffhunk://#diff-7199660fb0596d2c9b10cf83a06c4b4abcd5cf0577106ef86981fbd2b6325692R169) [[4]](diffhunk://#diff-7199660fb0596d2c9b10cf83a06c4b4abcd5cf0577106ef86981fbd2b6325692R226-R241)

**Prompt/documentation improvements:**
- Enhanced abbreviation handling instructions in the lecture prompt (`artificial_u/prompts/lecture.py`).