### PR TITLE
feat: course album art generation

### DIFF
--- a/alembic/versions/b3c4d5e6f7a8_add_course_image_fields.py
+++ b/alembic/versions/b3c4d5e6f7a8_add_course_image_fields.py
@@ -1,0 +1,26 @@
+"""add course image_url and image_created_with
+
+Revision ID: b3c4d5e6f7a8
+Revises: 9082ad4c555e
+Create Date: 2026-04-20 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "b3c4d5e6f7a8"
+down_revision = "9082ad4c555e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("courses", sa.Column("image_url", sa.String(), nullable=True))
+    op.add_column("courses", sa.Column("image_created_with", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("courses", "image_created_with")
+    op.drop_column("courses", "image_url")

--- a/artificial_u/api/dependencies.py
+++ b/artificial_u/api/dependencies.py
@@ -319,6 +319,7 @@ def get_professor_service(
 def get_course_service(
     repository_factory: RepositoryFactory = Depends(get_repository_factory),
     professor_service: ProfessorService = Depends(get_professor_service),
+    job_enqueue_service: JobEnqueueService = Depends(get_job_enqueue_service),
 ) -> CourseService:
     """
     Get a course service instance.
@@ -365,6 +366,7 @@ def get_course_service(
         professor_service=professor_service,
         department_selector_service=department_selector_service,
         professor_selector_service=professor_selector_service,
+        job_enqueue_service=job_enqueue_service,
         logger=logging.getLogger("artificial_u.services.course_service"),
     )
 
@@ -592,6 +594,7 @@ def get_course_api_service(
     professor_service: ProfessorService = Depends(get_professor_service),
     course_service: CourseService = Depends(get_course_service),
     storage_service: StorageService = Depends(get_storage_service),
+    image_service: ImageService = Depends(get_image_service),
 ) -> CourseApiService:
     """
     Get a course API service instance.
@@ -602,6 +605,7 @@ def get_course_api_service(
         professor_service: Professor service
         course_service: Core course service with smart selection
         storage_service: Storage service
+        image_service: Image generation service
 
     Returns:
         CourseApiService instance
@@ -612,6 +616,7 @@ def get_course_api_service(
         professor_service=professor_service,
         course_service=course_service,
         storage_service=storage_service,
+        image_service=image_service,
         logger=logging.getLogger("artificial_u.api.services.course_service"),
     )
 

--- a/artificial_u/api/models/courses.py
+++ b/artificial_u/api/models/courses.py
@@ -41,6 +41,10 @@ class CourseBase(BaseModel):
     # Attribution (not required for create)
     created_by: Optional[int] = Field(None, description="Student ID who created the course")
     created_with: Optional[str] = Field(None, description="Name of LLM used, if any")
+    image_url: Optional[str] = Field(None, description="URL of AI-generated course album art")
+    image_created_with: Optional[str] = Field(
+        None, description="Image model used to generate course art, if any"
+    )
     # Timestamps
     created_at: Optional[datetime] = Field(None, description="Course creation timestamp")
     updated_at: Optional[datetime] = Field(None, description="Course last update timestamp")

--- a/artificial_u/api/routers/courses.py
+++ b/artificial_u/api/routers/courses.py
@@ -139,6 +139,51 @@ async def get_course_by_code(
 
 
 @router.post(
+    "/{course_id}/generate-image",
+    response_model=CourseResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Generate course album art",
+    description=(
+        "Generates or regenerates AI album-art imagery for a course. "
+        "Only the creator or an admin can modify a course."
+    ),
+    responses={
+        404: {"description": "Course not found"},
+        403: {"description": "Forbidden - user doesn't own this course"},
+        500: {"description": "Image generation failed"},
+    },
+    dependencies=[require_coins(cost=get_settings().COIN_COST_COURSE_IMAGE)],
+)
+async def generate_course_image(
+    course_id: int = Path(..., description="The ID of the course to generate art for"),
+    course_service: CourseApiService = Depends(get_course_api_service),
+    student: Student = Depends(ensure_student),
+):
+    """
+    Generate album art for a course (sync; may take several minutes).
+    """
+    updated = await course_service.generate_course_image(course_id, student.id, student.role)
+    if updated:
+        return updated
+
+    try:
+        existing = course_service.get_course(course_id)
+    except HTTPException as e:
+        if e.status_code == status.HTTP_404_NOT_FOUND:
+            raise
+        raise
+    if existing is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Course with ID {course_id} not found",
+        )
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail=f"Failed to generate image for course {course_id}",
+    )
+
+
+@router.post(
     "",
     response_model=CourseResponse,
     status_code=status.HTTP_201_CREATED,

--- a/artificial_u/api/services/course_service.py
+++ b/artificial_u/api/services/course_service.py
@@ -30,6 +30,7 @@ from artificial_u.models.repositories import RepositoryFactory
 from artificial_u.services import (
     ContentService,
     CourseService,
+    ImageService,
     ProfessorService,
     StorageService,
 )
@@ -52,6 +53,7 @@ class CourseApiService(BaseApiService[CoreCourse, CourseResponse, CoursesListRes
         repository_factory: RepositoryFactory,
         course_service: CourseService,
         storage_service: "StorageService",
+        image_service: ImageService,
         logger=None,
     ):
         """
@@ -63,6 +65,7 @@ class CourseApiService(BaseApiService[CoreCourse, CourseResponse, CoursesListRes
             professor_service: Core ProfessorService instance.
             course_service: Core CourseService instance with smart selection.
             storage_service: Storage service for file operations.
+            image_service: Image generation service for course album art.
             logger: Optional logger instance.
         """
         super().__init__(logger)
@@ -88,6 +91,7 @@ class CourseApiService(BaseApiService[CoreCourse, CourseResponse, CoursesListRes
             course_service=self.core_service,
             professor_service=professor_service,
             content_service=content_service,
+            image_service=image_service,
             repository_factory=repository_factory,
             job_enqueue_service=job_enqueue_service,
             logger=self.logger,
@@ -538,6 +542,38 @@ class CourseApiService(BaseApiService[CoreCourse, CourseResponse, CoursesListRes
             self._handle_database_error("publish course", e)
         except Exception as e:
             self._handle_general_error("publish course", e)
+
+    async def generate_course_image(
+        self, course_id: int, student_id: int, role: str
+    ) -> Optional[CourseResponse]:
+        """
+        Generate or regenerate AI album art for a course (sync; may take minutes).
+
+        Ownership is enforced via verify_asset_ownership (creator or admin).
+        """
+        try:
+            course_model = self.core_service.get_course(course_id)
+
+            from artificial_u.api.security.auth0 import verify_asset_ownership
+
+            verify_asset_ownership(student_id, course_model.created_by, role, "course")
+
+            updated_course = await self.generator_service.generate_and_set_course_image(
+                course_id=course_id
+            )
+            if updated_course:
+                return self._build_course_response(updated_course)
+            return None
+
+        except CourseNotFoundError:
+            return None
+
+        except Exception as e:
+            self.logger.error(
+                f"Error generating image for course {course_id}: {e}",
+                exc_info=True,
+            )
+            return None
 
     def get_course_professor(self, course_id: int) -> ProfessorBrief:
         """

--- a/artificial_u/config/settings.py
+++ b/artificial_u/config/settings.py
@@ -151,6 +151,7 @@ class Settings(BaseSettings):
     COIN_COST_TOPIC_GENERATION: int = 3
     COIN_COST_PROFESSOR_GENERATION: int = 0
     COIN_COST_PROFESSOR_IMAGE: int = 2
+    COIN_COST_COURSE_IMAGE: int = 2
     COIN_COST_DEPARTMENT_GENERATION: int = 0
 
     # Async worker and rate limiting
@@ -275,6 +276,7 @@ class Settings(BaseSettings):
             "coin_cost_topic_generation": self.COIN_COST_TOPIC_GENERATION,
             "coin_cost_professor_generation": self.COIN_COST_PROFESSOR_GENERATION,
             "coin_cost_professor_image": self.COIN_COST_PROFESSOR_IMAGE,
+            "coin_cost_course_image": self.COIN_COST_COURSE_IMAGE,
             "coin_cost_department_generation": self.COIN_COST_DEPARTMENT_GENERATION,
         }
 

--- a/artificial_u/models/core.py
+++ b/artificial_u/models/core.py
@@ -208,6 +208,9 @@ class Course(BaseModel):
     # Attribution
     created_by: Optional[int] = None
     created_with: Optional[str] = None
+    # Album art (AI-generated course thumbnail)
+    image_url: Optional[str] = None
+    image_created_with: Optional[str] = None
     # Timestamps
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None

--- a/artificial_u/models/database.py
+++ b/artificial_u/models/database.py
@@ -43,6 +43,8 @@ class CourseModel(Base):
     # New attribution fields
     created_by = Column(Integer, ForeignKey("students.id"), nullable=True)
     created_with = Column(String, nullable=True)
+    image_url = Column(String, nullable=True)
+    image_created_with = Column(String, nullable=True)
     created_at = Column(DateTime, nullable=False, default=datetime.now)
     updated_at = Column(DateTime, nullable=False, default=datetime.now)
 

--- a/artificial_u/models/repositories/course.py
+++ b/artificial_u/models/repositories/course.py
@@ -60,6 +60,8 @@ class CourseRepository(BaseRepository):
             professor_id=db_course.professor_id,
             created_by=db_course.created_by,
             created_with=db_course.created_with,
+            image_url=db_course.image_url,
+            image_created_with=db_course.image_created_with,
             created_at=db_course.created_at,
             updated_at=db_course.updated_at,
             student=course_student,
@@ -85,6 +87,8 @@ class CourseRepository(BaseRepository):
                 professor_id=course.professor_id,
                 created_by=course.created_by,
                 created_with=course.created_with,
+                image_url=getattr(course, "image_url", None),
+                image_created_with=getattr(course, "image_created_with", None),
             )
 
             session.add(db_course)
@@ -141,6 +145,10 @@ class CourseRepository(BaseRepository):
             db_course.professor_id = course.professor_id
             db_course.created_by = course.created_by
             db_course.created_with = course.created_with
+            if hasattr(db_course, "image_url"):
+                db_course.image_url = getattr(course, "image_url", None)
+            if hasattr(db_course, "image_created_with"):
+                db_course.image_created_with = getattr(course, "image_created_with", None)
 
             session.commit()
             session.refresh(db_course)

--- a/artificial_u/prompts/__init__.py
+++ b/artificial_u/prompts/__init__.py
@@ -6,10 +6,11 @@ used across the Artificial-U system.
 
 from artificial_u.prompts.base import PromptTemplate
 from artificial_u.prompts.course import get_course_prompt
+from artificial_u.prompts.course_image import format_course_image_prompt
 from artificial_u.prompts.department import get_department_prompt
-from artificial_u.prompts.image import format_professor_image_prompt
 from artificial_u.prompts.lecture import get_lecture_prompt
 from artificial_u.prompts.professor import get_professor_prompt
+from artificial_u.prompts.professor_image import format_professor_image_prompt
 from artificial_u.prompts.system import get_system_prompt
 from artificial_u.prompts.topics import get_next_topic_prompt
 
@@ -21,6 +22,7 @@ __all__ = [
     # Department prompts
     "get_department_prompt",
     # Image prompts
+    "format_course_image_prompt",
     "format_professor_image_prompt",
     # Lecture prompts
     "get_lecture_prompt",

--- a/artificial_u/prompts/course_image.py
+++ b/artificial_u/prompts/course_image.py
@@ -1,0 +1,92 @@
+"""
+Image generation prompts for course album art (ArtificialU).
+"""
+
+from typing import Any, Optional
+
+
+def _truncate_for_themes(text: str, max_len: int = 500) -> str:
+    text = text.strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 1].rstrip() + "…"
+
+
+def format_course_image_prompt(
+    course: Any,
+    professor: Optional[Any] = None,
+    aspect_ratio: str = "1:1",
+) -> str:
+    """
+    Format a prompt for generating square album-art style course imagery.
+
+    Args:
+        course: A Course object (title, code, level, description expected).
+        professor: Optional Professor object; name may appear in optional credits.
+        aspect_ratio: The aspect ratio for the generated image (default: "1:1").
+
+    Returns:
+        A formatted prompt string for the image generation API.
+    """
+    title = getattr(course, "title", None) or "Untitled course"
+    code = getattr(course, "code", None)
+    level = getattr(course, "level", None)
+    description = getattr(course, "description", None)
+
+    course_parts = [f"Course: {title}"]
+    if code:
+        course_parts.append(f"Code: {code}.")
+    if level:
+        course_parts.append(f"Level: {level}.")
+    course_line = " ".join(course_parts)
+
+    themes_line = ""
+    if description:
+        themes_line = (
+            "Themes (inform visuals only; do not render as a paragraph of text): "
+            f"{_truncate_for_themes(description)}"
+        )
+
+    prof_name = getattr(professor, "name", None) if professor is not None else None
+    optional_credits = ""
+    if prof_name:
+        optional_credits = (
+            f"Optional credits: You may include the instructor name ({prof_name}) "
+            "in lettering if it fits the 0–12 word limit; it is not required."
+        )
+
+    prompt_sections = [
+        "Subject: Album art for a university course.",
+        course_line,
+    ]
+
+    if themes_line:
+        prompt_sections.append(themes_line)
+
+    if optional_credits:
+        prompt_sections.append(optional_credits)
+
+    prompt_sections.extend(
+        [
+            "",
+            "Art Direction: Highly polished digital illustration in the spirit of album cover art "
+            "(think eclectic SoHo record store, a weird aunt's basement crate, "
+            "or a festival merch stand). Semi-realistic, smooth textures, illustrative style "
+            "similar to Riot Games art, Hearthstone key art, or ArtStation trending — "
+            "but as a record sleeve / square thumbnail, not a portrait.",
+            "Vibe: Maximalism encouraged. Pursue diverse, unique moods; saturated or moody palettes; "
+            "motif and color should read clearly at thumbnail size. Do NOT converge on one "
+            "house style — vary composition, palette, era nods, and graphic idiom between runs.",
+            "Typography: Use between 0 and 12 words of text total on the image. "
+            "Course title is encouraged but may be abbreviated if long. "
+            "Do not add any product branding, URLs, or the string 'Artificial-U'. "
+            "Keep lettering legible; no paragraphs or walls of text.",
+            "Negative Prompt: Not photorealistic. Not grainy. Not a portrait of a person. "
+            "No watermarks. No lorem ipsum. No academic-stock clichés (chalkboards, graduation "
+            "caps) unless the course title clearly demands them.",
+            "Details: High resolution, vivid colors, 8k, masterpiece.",
+            f"Aspect Ratio: {aspect_ratio}",
+        ]
+    )
+
+    return "\n".join(prompt_sections)

--- a/artificial_u/prompts/professor_image.py
+++ b/artificial_u/prompts/professor_image.py
@@ -1,5 +1,5 @@
 """
-Image generation prompts for ArtificialU.
+Image generation prompts for professor portraits (ArtificialU).
 """
 
 

--- a/artificial_u/services/course_generator_service.py
+++ b/artificial_u/services/course_generator_service.py
@@ -24,9 +24,12 @@ from artificial_u.prompts import (
     get_system_prompt,
 )
 from artificial_u.services.content_service import ContentService
+from artificial_u.services.image_service import ImageService
 from artificial_u.utils import (
     ContentGenerationError,
     DatabaseError,
+    GenerationError,
+    ProfessorNotFoundError,
 )
 
 
@@ -38,6 +41,7 @@ class CourseGeneratorService:
         course_service,
         professor_service,
         content_service: ContentService,
+        image_service: ImageService,
         repository_factory: RepositoryFactory,
         job_enqueue_service,
         logger=None,
@@ -50,12 +54,14 @@ class CourseGeneratorService:
             professor_service: Professor service for professor-related operations
             content_service: Content generation service
             repository_factory: Repository factory instance
+            image_service: Image generation and storage service
             job_enqueue_service: Job enqueueing service for background tasks
             logger: Optional logger instance
         """
         self.course_service = course_service
         self.professor_service = professor_service
         self.content_service = content_service
+        self.image_service = image_service
         self.repository_factory = repository_factory
         self.job_enqueue_service = job_enqueue_service
         self.logger = logger or logging.getLogger(__name__)
@@ -318,3 +324,101 @@ class CourseGeneratorService:
                     exc_info=True,
                 )
                 raise DatabaseError("Error fetching recent courses from repository.") from e
+
+    async def generate_and_set_course_image(
+        self, course_id: int, aspect_ratio: str = "1:1"
+    ) -> Course:
+        """
+        Generate album art for a course and persist image_url / image_created_with.
+
+        Args:
+            course_id: Course primary key
+            aspect_ratio: Image aspect ratio (default 1:1 for MP3 / UI thumbnails)
+
+        Returns:
+            Updated Course model
+
+        Raises:
+            CourseNotFoundError: If the course does not exist
+            GenerationError: If generation or persistence fails
+        """
+        self.logger.info(f"Generating album art for course ID: {course_id}")
+
+        course = self.course_service.get_course(course_id)
+
+        professor = None
+        if course.professor_id:
+            try:
+                professor = self.professor_service.get_professor(course.professor_id)
+            except ProfessorNotFoundError:
+                self.logger.warning(
+                    "Professor %s not found; course image prompt will omit optional credits",
+                    course.professor_id,
+                )
+
+        try:
+            result = await self.image_service.generate_course_image(
+                course=course,
+                professor=professor,
+                aspect_ratio=aspect_ratio,
+            )
+        except Exception as e:
+            self.logger.error(
+                f"Image generation step failed for course {course_id}: {e}",
+                exc_info=True,
+            )
+            raise GenerationError(f"Failed to generate image for course {course_id}") from e
+
+        image_key = self._validate_course_image_result(result, course_id)
+        image_url = self._get_course_image_url_from_key(image_key, course_id)
+
+        settings = get_settings()
+        try:
+            updated = self.course_service.update_course(
+                course_id,
+                {
+                    "image_url": image_url,
+                    "image_created_with": settings.IMAGE_GENERATION_MODEL,
+                },
+            )
+            self.logger.info(
+                f"Course {course_id} updated with album art (model: {settings.IMAGE_GENERATION_MODEL})."
+            )
+            return updated
+        except Exception as e:
+            self.logger.error(f"Failed to update course {course_id} with image URL: {e}")
+            raise
+
+    def _validate_course_image_result(self, result, course_id: int) -> str:
+        """Validate image generation result and return the storage key."""
+        if not result.success:
+            error_msg = f"Image generation failed for course {course_id}"
+            if result.error:
+                error_msg += f": {result.error.error_type.value} - {result.error}"
+                if result.error.backend:
+                    error_msg += f" (backend: {result.error.backend})"
+            self.logger.error(error_msg)
+            raise GenerationError(error_msg)
+
+        if not result.image_keys:
+            self.logger.error(
+                f"Image generation succeeded but returned no keys for course {course_id}"
+            )
+            raise GenerationError(
+                f"Image generation succeeded but yielded no result for course {course_id}"
+            )
+
+        return result.image_keys[0]
+
+    def _get_course_image_url_from_key(self, image_key: str, course_id: int) -> str:
+        """Build public URL for a stored image object key."""
+        try:
+            bucket = self.image_service.storage_service.images_bucket
+            image_url = self.image_service.storage_service.get_file_url(
+                bucket=bucket, object_name=image_key
+            )
+            self.logger.info(f"Image URL for course {course_id}: {image_url}")
+            return image_url
+        except Exception as e:
+            self.logger.error(f"Failed to get image URL for key {image_key}: {e}", exc_info=True)
+            raise GenerationError(f"Failed to construct image URL for course {course_id}") from e

--- a/artificial_u/services/course_service.py
+++ b/artificial_u/services/course_service.py
@@ -31,6 +31,7 @@ class CourseService:
         professor_service: ProfessorService,
         department_selector_service,
         professor_selector_service,
+        job_enqueue_service=None,
         logger=None,
     ):
         """
@@ -41,12 +42,14 @@ class CourseService:
             professor_service: Service for professor operations
             department_selector_service: Service for smart department selection
             professor_selector_service: Service for smart professor selection
+            job_enqueue_service: Optional service for enqueueing background jobs (e.g. album art)
             logger: Optional logger instance
         """
         self.repository_factory = repository_factory
         self.professor_service = professor_service
         self.department_selector_service = department_selector_service
         self.professor_selector_service = professor_selector_service
+        self.job_enqueue_service = job_enqueue_service
         self.logger = logger or logging.getLogger(__name__)
 
     # --- CRUD Methods --- #
@@ -186,6 +189,22 @@ class CourseService:
         try:
             created_course = self.repository_factory.course.create(course)
             self.logger.info(f"Course created with ID: {created_course.id}")
+            if self.job_enqueue_service:
+                try:
+                    if not getattr(created_course, "image_url", None):
+                        self.job_enqueue_service.enqueue_course_image_generation(created_course.id)
+                    else:
+                        self.logger.debug(
+                            "Skipping course image job on create: course %s already has image",
+                            created_course.id,
+                        )
+                except Exception as bg_e:
+                    self.logger.error(
+                        "Failed to enqueue album art generation for course %s: %s",
+                        created_course.id,
+                        bg_e,
+                        exc_info=True,
+                    )
             return created_course, professor
         except Exception as e:
             error_msg = f"Failed to save course {code}: {str(e)}"

--- a/artificial_u/services/image_service.py
+++ b/artificial_u/services/image_service.py
@@ -12,8 +12,9 @@ from google.genai.errors import ClientError, ServerError
 from google.genai.types import Modality
 
 from artificial_u.integrations import gemini_client, openai_client
-from artificial_u.models.core import Professor
-from artificial_u.prompts.image import format_professor_image_prompt
+from artificial_u.models.core import Course, Professor
+from artificial_u.prompts.course_image import format_course_image_prompt
+from artificial_u.prompts.professor_image import format_professor_image_prompt
 from artificial_u.services.storage_service import StorageService
 
 logger = logging.getLogger(__name__)
@@ -548,6 +549,30 @@ class ImageService:
                 logger.error(f"Failed to upload image prompt log: {filename}")
         except Exception as e:
             logger.error(f"Failed to save image prompt log {filename}: {str(e)}")
+
+    async def generate_course_image(
+        self,
+        course: Course,
+        professor: Optional[Professor] = None,
+        aspect_ratio: str = "1:1",
+    ) -> ImageGenerationResult:
+        """
+        Generates album-art style imagery for a course.
+
+        Args:
+            course: The Course object
+            professor: Optional professor for optional name/credits in the prompt
+            aspect_ratio: Desired aspect ratio (default square for thumbnails / ID3 art)
+
+        Returns:
+            An ImageGenerationResult object with success/failure information.
+        """
+        prompt = format_course_image_prompt(course, professor=professor, aspect_ratio=aspect_ratio)
+        cid = getattr(course, "id", None)
+        logger.info(
+            f"Generating course album art for course {cid} ({getattr(course, 'title', '?')})"
+        )
+        return await self.generate_image(prompt=prompt, aspect_ratio=aspect_ratio)
 
     async def generate_professor_image(
         self, professor: Professor, aspect_ratio: str = "1:1"

--- a/artificial_u/services/job_enqueue_service.py
+++ b/artificial_u/services/job_enqueue_service.py
@@ -64,6 +64,35 @@ class JobEnqueueService:
             self.logger.error(error_msg, exc_info=True)
             raise DatabaseError(error_msg) from e
 
+    def enqueue_course_image_generation(self, course_id: int, aspect_ratio: str = "1:1") -> None:
+        """
+        Enqueue a background job to generate album art for a course.
+
+        Args:
+            course_id: The ID of the course
+            aspect_ratio: The desired aspect ratio for the image
+
+        Raises:
+            DatabaseError: If job enqueueing fails
+        """
+        try:
+            job_repo = self.repository_factory.job
+            job = job_repo.create(
+                kind="generate_course_image",
+                payload={
+                    "course_id": course_id,
+                    "aspect_ratio": aspect_ratio,
+                },
+            )
+            job_id = job.id
+            self.logger.info(
+                f"Enqueued course image generation job {job_id} for course {course_id}"
+            )
+        except Exception as e:
+            error_msg = f"Failed to enqueue course image generation job for course {course_id}: {e}"
+            self.logger.error(error_msg, exc_info=True)
+            raise DatabaseError(error_msg) from e
+
     def enqueue_lecture_summary_generation(
         self, lecture_id: int, *, topic_id: int | None = None
     ) -> None:

--- a/artificial_u/services/job_service.py
+++ b/artificial_u/services/job_service.py
@@ -86,6 +86,7 @@ class JobService:
             "generate_lecture_audio": self._handle_generate_lecture_audio,
             "generate_lecture_timeline": self._handle_generate_lecture_timeline,
             "generate_professor_image": self._handle_generate_professor_image,
+            "generate_course_image": self._handle_generate_course_image,
             # Export tasks
             "export_course": self._handle_export_course,
             # Quickstart tasks
@@ -310,6 +311,17 @@ class JobService:
         )
         return {"professor_id": updated.id, "image_url": getattr(updated, "image_url", None)}
 
+    async def _handle_generate_course_image(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        service = self._course_generator_service_instance()
+        course_id = payload.get("course_id")
+        aspect_ratio = payload.get("aspect_ratio", "1:1")
+        if course_id is None:
+            raise ValueError("course_id is required")
+        updated = await service.generate_and_set_course_image(
+            course_id=course_id, aspect_ratio=aspect_ratio
+        )
+        return {"course_id": updated.id, "image_url": getattr(updated, "image_url", None)}
+
     async def _handle_export_course(self, payload: Dict[str, Any]) -> Dict[str, Any]:
         """Export a course with all related data and assets."""
         service = self._course_export_service_instance()
@@ -467,6 +479,7 @@ class JobService:
                 professor_service=self._professor_service_instance(),
                 department_selector_service=self._department_selector_service_instance(),
                 professor_selector_service=self._professor_selector_service_instance(),
+                job_enqueue_service=self._job_enqueue_service_instance(),
                 logger=self.logger,
             )
         return self._course_service
@@ -532,6 +545,7 @@ class JobService:
                 course_service=self._course_service_instance(),
                 professor_service=self._professor_service_instance(),
                 content_service=self._content_service_instance(),
+                image_service=self._image_service_instance(),
                 repository_factory=self.repository_factory,
                 job_enqueue_service=self._job_enqueue_service_instance(),
                 logger=self.logger,

--- a/artificial_u/system.py
+++ b/artificial_u/system.py
@@ -276,6 +276,7 @@ class UniversitySystem:
             professor_service=self.professor_service,
             department_selector_service=self.department_selector_service,
             professor_selector_service=self.professor_selector_service,
+            job_enqueue_service=job_enqueue_service,
             logger=logging.getLogger("artificial_u.services.course_service"),
         )
 

--- a/tests/api/test_courses.py
+++ b/tests/api/test_courses.py
@@ -74,6 +74,7 @@ def mock_api_service(monkeypatch):
         "get_course_department": MagicMock(),
         "get_course_lectures": MagicMock(),
         "generate_course": AsyncMock(),
+        "generate_course_image": AsyncMock(),
     }
 
     # --- Configure Mock Return Values ---
@@ -167,6 +168,18 @@ def mock_api_service(monkeypatch):
         0
     ]  # Return a sample generated course
 
+    # GENERATE course album art
+    def _mock_generate_course_image(course_id: int, student_id: int, role: str):
+        base = next((c for c in sample_courses_base if c.id == course_id), None)
+        if not base:
+            return None
+        data = base.model_dump()
+        data["image_url"] = "https://example.com/album.png"
+        data["image_created_with"] = "gemini-3.1-flash-image-preview"
+        return CourseResponse(**data)
+
+    mock_service["generate_course_image"].side_effect = _mock_generate_course_image
+
     # --- Apply Patches ---
     base_path = "artificial_u.api.services.CourseApiService"
     monkeypatch.setattr(f"{base_path}.get_courses", mock_service["get_courses"])
@@ -179,6 +192,7 @@ def mock_api_service(monkeypatch):
     monkeypatch.setattr(f"{base_path}.get_course_department", mock_service["get_course_department"])
     monkeypatch.setattr(f"{base_path}.get_course_lectures", mock_service["get_course_lectures"])
     monkeypatch.setattr(f"{base_path}.generate_course", mock_service["generate_course"])
+    monkeypatch.setattr(f"{base_path}.generate_course_image", mock_service["generate_course_image"])
 
     return mock_service
 
@@ -388,6 +402,8 @@ def test_create_course(client: TestClient, mock_api_service):
         **new_course_data,
         "created_by": None,
         "created_with": None,
+        "image_url": None,
+        "image_created_with": None,
         "created_at": None,
         "updated_at": None,
         "status": "hidden",
@@ -551,6 +567,24 @@ def test_generate_course_partial_data(client: TestClient, mock_api_service: Magi
     assert isinstance(called_with_arg, CourseGenerate)
     assert called_with_arg.partial_attributes == generation_request_data["partial_attributes"]
     assert called_with_arg.freeform_prompt == generation_request_data["freeform_prompt"]
+
+
+@pytest.mark.unit
+def test_generate_course_image(client: TestClient, mock_api_service):
+    """POST /courses/{id}/generate-image delegates to CourseApiService."""
+    response = client.post("/api/v1/courses/1/generate-image")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["image_url"] == "https://example.com/album.png"
+    assert data["image_created_with"] == "gemini-3.1-flash-image-preview"
+    mock_api_service["generate_course_image"].assert_called_once_with(1, 1, "admin")
+
+    mock_api_service["generate_course_image"].reset_mock()
+    mock_api_service["generate_course_image"].return_value = None
+    mock_api_service["generate_course_image"].side_effect = None
+    response = client.post("/api/v1/courses/999/generate-image")
+    assert response.status_code == 404
+    mock_api_service["generate_course_image"].assert_called_once_with(999, 1, "admin")
 
 
 @pytest.mark.unit

--- a/tests/integration/services/test_course_service.py
+++ b/tests/integration/services/test_course_service.py
@@ -122,11 +122,18 @@ def course_service(
     repository_factory, professor_service, department_selector_service, professor_selector_service
 ):
     """Create a CourseService with selector services."""
+    from artificial_u.services.job_enqueue_service import JobEnqueueService
+
+    job_enqueue_service = JobEnqueueService(
+        repository_factory=repository_factory,
+        logger=logging.getLogger(__name__),
+    )
     return CourseService(
         repository_factory=repository_factory,
         professor_service=professor_service,
         department_selector_service=department_selector_service,
         professor_selector_service=professor_selector_service,
+        job_enqueue_service=job_enqueue_service,
         logger=logging.getLogger(__name__),
     )
 

--- a/tests/integration/services/test_lecture_service.py
+++ b/tests/integration/services/test_lecture_service.py
@@ -119,11 +119,18 @@ def course_service(
     repository_factory, professor_service, department_selector_service, professor_selector_service
 ):
     """Create a CourseService with selector services."""
+    from artificial_u.services.job_enqueue_service import JobEnqueueService
+
+    job_enqueue_service = JobEnqueueService(
+        repository_factory=repository_factory,
+        logger=logging.getLogger(__name__),
+    )
     return CourseService(
         repository_factory=repository_factory,
         professor_service=professor_service,
         department_selector_service=department_selector_service,
         professor_selector_service=professor_selector_service,
+        job_enqueue_service=job_enqueue_service,
         logger=logging.getLogger(__name__),
     )
 

--- a/tests/integration/services/test_topic_service.py
+++ b/tests/integration/services/test_topic_service.py
@@ -72,11 +72,18 @@ def course_service(
     repository_factory, professor_service, department_selector_service, professor_selector_service
 ):
     """Create a CourseService with selector services."""
+    from artificial_u.services.job_enqueue_service import JobEnqueueService
+
+    job_enqueue_service = JobEnqueueService(
+        repository_factory=repository_factory,
+        logger=logging.getLogger(__name__),
+    )
     return CourseService(
         repository_factory=repository_factory,
         professor_service=professor_service,
         department_selector_service=department_selector_service,
         professor_selector_service=professor_selector_service,
+        job_enqueue_service=job_enqueue_service,
         logger=logging.getLogger(__name__),
     )
 

--- a/tests/unit/models/test_course_repository.py
+++ b/tests/unit/models/test_course_repository.py
@@ -36,6 +36,8 @@ class TestCourseRepository:
         mock_course.professor_id = 1
         mock_course.created_by = 1
         mock_course.created_with = "test-llm"
+        mock_course.image_url = None
+        mock_course.image_created_with = None
         mock_course.created_at = None
         mock_course.updated_at = None
         mock_course.student = None  # Mock student relationship
@@ -154,6 +156,8 @@ class TestCourseRepository:
         mock_course1.professor_id = 1
         mock_course1.created_by = 1
         mock_course1.created_with = "test-llm"
+        mock_course1.image_url = None
+        mock_course1.image_created_with = None
         mock_course1.created_at = None
         mock_course1.updated_at = None
         mock_course1.student = None
@@ -171,6 +175,8 @@ class TestCourseRepository:
         mock_course2.professor_id = 2
         mock_course2.created_by = 2
         mock_course2.created_with = "test-llm-2"
+        mock_course2.image_url = None
+        mock_course2.image_created_with = None
         mock_course2.created_at = None
         mock_course2.updated_at = None
         mock_course2.student = None
@@ -209,6 +215,8 @@ class TestCourseRepository:
         mock_course.professor_id = 1
         mock_course.created_by = 1
         mock_course.created_with = "test-llm"
+        mock_course.image_url = None
+        mock_course.image_created_with = None
         mock_course.created_at = None
         mock_course.updated_at = None
         mock_course.student = None

--- a/tests/unit/prompts/test_course_image_prompt.py
+++ b/tests/unit/prompts/test_course_image_prompt.py
@@ -1,0 +1,48 @@
+"""Unit tests for course album-art image prompts."""
+
+from artificial_u.models.core import Course, Professor
+from artificial_u.prompts.course_image import format_course_image_prompt
+
+
+def test_format_course_image_prompt_contains_core_sections():
+    course = Course(
+        id=1,
+        code="CS101",
+        title="Introduction to Testing",
+        description="A course about unit tests and mocks.",
+        level="Undergraduate",
+        department_id=1,
+        professor_id=1,
+    )
+    prompt = format_course_image_prompt(course, aspect_ratio="1:1")
+    assert "Album art for a university course" in prompt
+    assert "Introduction to Testing" in prompt
+    assert "CS101" in prompt
+    assert "Undergraduate" in prompt
+    assert "unit tests" in prompt or "Themes" in prompt
+    assert "0 and 12 words" in prompt
+    assert "Negative Prompt" in prompt
+    assert "Not photorealistic" in prompt
+    assert "Aspect Ratio: 1:1" in prompt
+
+
+def test_format_course_image_prompt_optional_professor():
+    course = Course(
+        id=2,
+        code="ART99",
+        title="Art History",
+        description=None,
+        level=None,
+        department_id=1,
+        professor_id=1,
+    )
+    prof = Professor(
+        id=1,
+        name="Dr. Example",
+        title="Prof",
+        specialization="Art",
+        department_id=1,
+    )
+    prompt = format_course_image_prompt(course, professor=prof, aspect_ratio="16:9")
+    assert "Dr. Example" in prompt
+    assert "Aspect Ratio: 16:9" in prompt

--- a/tests/unit/prompts/test_image_prompt.py
+++ b/tests/unit/prompts/test_image_prompt.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from artificial_u.prompts.image import format_professor_image_prompt
+from artificial_u.prompts.professor_image import format_professor_image_prompt
 
 
 class MockProfessor:

--- a/tests/unit/services/test_course_generator_image.py
+++ b/tests/unit/services/test_course_generator_image.py
@@ -1,0 +1,113 @@
+"""Unit tests for course album art generation orchestration."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from artificial_u.models.core import Course
+from artificial_u.services.course_generator_service import CourseGeneratorService
+from artificial_u.services.image_service import ImageGenerationResult
+from artificial_u.utils import GenerationError
+
+
+@pytest.mark.asyncio
+async def test_generate_and_set_course_image_updates_course(monkeypatch):
+    course = Course(
+        id=7,
+        code="TST100",
+        title="Test",
+        description="Desc",
+        department_id=1,
+        professor_id=None,
+        level="Ugrad",
+    )
+
+    course_service = MagicMock()
+    course_service.get_course.return_value = course
+    course_service.update_course = MagicMock(
+        return_value=Course(
+            id=7,
+            code="TST100",
+            title="Test",
+            description="Desc",
+            department_id=1,
+            professor_id=None,
+            level="Ugrad",
+            image_url="https://storage.example/img.png",
+            image_created_with="gemini-test",
+        )
+    )
+
+    professor_service = MagicMock()
+
+    image_service = MagicMock()
+    image_service.generate_course_image = AsyncMock(
+        return_value=ImageGenerationResult(success=True, image_keys=["abc.png"])
+    )
+    image_service.storage_service.images_bucket = "images"
+    image_service.storage_service.get_file_url = MagicMock(
+        return_value="https://storage.example/img.png"
+    )
+
+    job_enqueue = MagicMock()
+    repo = MagicMock()
+
+    monkeypatch.setattr(
+        "artificial_u.services.course_generator_service.get_settings",
+        lambda: MagicMock(IMAGE_GENERATION_MODEL="gemini-test"),
+    )
+
+    svc = CourseGeneratorService(
+        course_service=course_service,
+        professor_service=professor_service,
+        content_service=MagicMock(),
+        image_service=image_service,
+        repository_factory=repo,
+        job_enqueue_service=job_enqueue,
+        logger=MagicMock(),
+    )
+
+    out = await svc.generate_and_set_course_image(7)
+    assert out.image_url == "https://storage.example/img.png"
+    course_service.update_course.assert_called_once()
+    call_kw = course_service.update_course.call_args[0][1]
+    assert call_kw["image_url"] == "https://storage.example/img.png"
+    assert call_kw["image_created_with"] == "gemini-test"
+
+
+@pytest.mark.asyncio
+async def test_generate_and_set_course_image_raises_on_failed_generation(monkeypatch):
+    course = Course(
+        id=8,
+        code="TST200",
+        title="Test",
+        description="Desc",
+        department_id=1,
+        professor_id=None,
+        level="Ugrad",
+    )
+    course_service = MagicMock()
+    course_service.get_course.return_value = course
+
+    image_service = MagicMock()
+    image_service.generate_course_image = AsyncMock(
+        return_value=ImageGenerationResult(success=False, image_keys=[])
+    )
+
+    monkeypatch.setattr(
+        "artificial_u.services.course_generator_service.get_settings",
+        lambda: MagicMock(IMAGE_GENERATION_MODEL="gemini-test"),
+    )
+
+    svc = CourseGeneratorService(
+        course_service=course_service,
+        professor_service=MagicMock(),
+        content_service=MagicMock(),
+        image_service=image_service,
+        repository_factory=MagicMock(),
+        job_enqueue_service=MagicMock(),
+        logger=MagicMock(),
+    )
+
+    with pytest.raises(GenerationError):
+        await svc.generate_and_set_course_image(8)

--- a/web/src/api/config.ts
+++ b/web/src/api/config.ts
@@ -75,6 +75,7 @@ export const ENDPOINTS = {
   courses: {
     list: '/v1/courses',
     detail: (id: number) => `/v1/courses/${String(id)}`,
+    generateImage: (id: number) => `/v1/courses/${String(id)}/generate-image`,
     lectures: (id: number) => `/v1/courses/${String(id)}/lectures`,
     professor: (id: number) => `/v1/courses/${String(id)}/professor`,
     department: (id: number) => `/v1/courses/${String(id)}/department`,

--- a/web/src/api/services/course-service.ts
+++ b/web/src/api/services/course-service.ts
@@ -2,7 +2,7 @@
  * Course service
  */
 import { httpClient } from '../client.js'
-import { ENDPOINTS } from '../config.js'
+import { ENDPOINTS, TIMEOUT_CONFIG } from '../config.js'
 import type {
   Course,
   CourseCreate,
@@ -66,6 +66,14 @@ export const courseService = {
 
   publishCourse: (courseId: number): Promise<Course> => {
     return httpClient.post<Course>(`${ENDPOINTS.courses.detail(courseId)}/publish`, {})
+  },
+
+  generateCourseImage: (courseId: number): Promise<Course> => {
+    return httpClient.post<Course>(
+      ENDPOINTS.courses.generateImage(courseId),
+      {},
+      { timeout: TIMEOUT_CONFIG.generation }
+    )
   },
 
   getCourseProfessor: (courseId: number): Promise<ProfessorBrief> => {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -42,6 +42,8 @@ export interface Course {
   status: CourseStatus
   created_by?: number | null
   created_with?: string | null
+  image_url?: string | null
+  image_created_with?: string | null
   created_at?: string | null
   updated_at?: string | null
   lectures_with_audio_count?: number

--- a/web/src/pages/CourseDetail.tsx
+++ b/web/src/pages/CourseDetail.tsx
@@ -295,6 +295,8 @@ const CourseDetail: Component = () => {
   const [exportMessage, setExportMessage] = createSignal('')
   const [isPublishing, setIsPublishing] = createSignal(false)
   const [topicGenMessage, setTopicGenMessage] = createSignal('')
+  const [isGeneratingImage, setIsGeneratingImage] = createSignal(false)
+  const [imageGenerationError, setImageGenerationError] = createSignal('')
 
   // Check if courseId is a valid number before creating resources
   const isValidId = !Number.isNaN(courseId)
@@ -431,6 +433,23 @@ const CourseDetail: Component = () => {
   }
 
   // Handler for publishing a course
+  const handleGenerateCourseImage = async () => {
+    if (!isValidId) return
+    setIsGeneratingImage(true)
+    setImageGenerationError('')
+    setError('')
+    try {
+      await courseService.generateCourseImage(courseId)
+      void refetch()
+    } catch (err: unknown) {
+      setImageGenerationError(
+        err instanceof Error ? err.message : 'Failed to generate course image'
+      )
+    } finally {
+      setIsGeneratingImage(false)
+    }
+  }
+
   const handlePublishCourse = () => {
     if (!isValidId) return
 
@@ -493,6 +512,14 @@ const CourseDetail: Component = () => {
                         </MagicButton>
                       </Show>
                       <Show when={auth.canModify(course().created_by)}>
+                        <MagicButton
+                          variant="ghost"
+                          onClick={() => void handleGenerateCourseImage()}
+                          isLoading={isGeneratingImage()}
+                          loadingText={t().common.generating}
+                        >
+                          {course().image_url ? 'Regenerate Image' : 'Generate Image'}
+                        </MagicButton>
                         <Button variant="primary" onClick={() => setIsEditing(true)}>
                           {t().courseDetail.editCourse}
                         </Button>
@@ -517,6 +544,12 @@ const CourseDetail: Component = () => {
                 <Show when={error()}>
                   <Alert variant="danger" class="mb-4">
                     {error()}
+                  </Alert>
+                </Show>
+
+                <Show when={imageGenerationError()}>
+                  <Alert variant="danger" class="mb-4">
+                    {imageGenerationError()}
                   </Alert>
                 </Show>
 
@@ -585,28 +618,44 @@ const CourseDetail: Component = () => {
                     </RequireRole>
                   }
                 >
-                  <div class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 mb-3">
-                    <h1 class="text-3xl font-display text-parchment-100">
-                      {course().code}: {course().title}
-                    </h1>
-                    <span
-                      class={`inline-flex items-center gap-1.5 px-3 py-1 text-sm font-medium rounded-full whitespace-nowrap self-start ${
-                        course().status === 'published'
-                          ? 'bg-green-500/20 text-green-300 border border-green-400/30'
-                          : 'bg-amber-500/20 text-amber-300 border border-amber-400/30'
-                      }`}
-                    >
-                      <span class="text-xs">{course().status === 'published' ? '✓' : '●'}</span>
-                      <span>
-                        {course().status === 'published'
-                          ? t().courseDetail.published
-                          : t().courseDetail.hidden}
-                      </span>
-                    </span>
+                  <div class="flex flex-col gap-6 md:flex-row md:items-start mb-6">
+                    <Show when={course().image_url}>
+                      <div class="shrink-0">
+                        <img
+                          src={course().image_url ?? ''}
+                          alt=""
+                          width={256}
+                          height={256}
+                          loading="lazy"
+                          class="w-48 h-48 md:w-64 md:h-64 rounded-lg border border-parchment-800/40 object-cover shadow-lg"
+                        />
+                      </div>
+                    </Show>
+                    <div class="flex flex-col gap-2 min-w-0 flex-1">
+                      <div class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4">
+                        <h1 class="text-3xl font-display text-parchment-100">
+                          {course().code}: {course().title}
+                        </h1>
+                        <span
+                          class={`inline-flex items-center gap-1.5 px-3 py-1 text-sm font-medium rounded-full whitespace-nowrap self-start ${
+                            course().status === 'published'
+                              ? 'bg-green-500/20 text-green-300 border border-green-400/30'
+                              : 'bg-amber-500/20 text-amber-300 border border-amber-400/30'
+                          }`}
+                        >
+                          <span class="text-xs">{course().status === 'published' ? '✓' : '●'}</span>
+                          <span>
+                            {course().status === 'published'
+                              ? t().courseDetail.published
+                              : t().courseDetail.hidden}
+                          </span>
+                        </span>
+                      </div>
+                      <p class="text-base italic text-parchment-200 font-serif">
+                        {course().description}
+                      </p>
+                    </div>
                   </div>
-                  <p class="text-base italic text-parchment-200 mb-6 font-serif">
-                    {course().description}
-                  </p>
 
                   {/* Metadata Section */}
                   <MetadataInfo

--- a/web/src/pages/Courses.tsx
+++ b/web/src/pages/Courses.tsx
@@ -7,7 +7,7 @@ import { useAuth } from '../auth/AuthProvider'
 import { RequireRole } from '../auth/RequireRole'
 import CourseForm from '../components/courses/CourseForm.jsx'
 import type { CourseFormData } from '../components/courses/types.jsx'
-import { Button } from '../components/ui'
+import { Alert, Button, MagicButton } from '../components/ui'
 import type { SelectOption } from '../components/ui/Select.jsx'
 import Select from '../components/ui/Select.jsx'
 import { useTranslations } from '../i18n'
@@ -29,6 +29,10 @@ const Courses: Component = () => {
   const [showCreateForm, setShowCreateForm] = createSignal(false)
   const [submitting, setSubmitting] = createSignal(false)
   const [formError, setFormError] = createSignal('')
+  const [isGeneratingCourseImageId, setIsGeneratingCourseImageId] = createSignal<number | null>(
+    null
+  )
+  const [courseImageError, setCourseImageError] = createSignal('')
 
   // Helper function to get student name safely
   const getStudentName = (course: Course): string => {
@@ -261,6 +265,77 @@ const Courses: Component = () => {
     }
   }
 
+  const handleGenerateCourseImage = async (courseId: number) => {
+    setCourseImageError('')
+    setIsGeneratingCourseImageId(courseId)
+    try {
+      await courseService.generateCourseImage(courseId)
+      void refetch()
+    } catch (error) {
+      setCourseImageError(error instanceof Error ? error.message : 'Failed to generate image')
+    } finally {
+      setIsGeneratingCourseImageId(null)
+    }
+  }
+
+  const CourseThumb: Component<{ course: Course; size: 'sm' | 'md' }> = (props) => {
+    const courseId = () => props.course.id
+    const isMissing = () => !props.course.image_url
+    const isLoading = () => isGeneratingCourseImageId() === courseId()
+
+    const boxClass = () =>
+      props.size === 'sm' ? 'h-12 w-12 rounded-md' : 'h-16 w-16 shrink-0 rounded-lg'
+
+    const imgClass = () =>
+      props.size === 'sm'
+        ? 'h-12 w-12 rounded-md object-cover border border-parchment-800/30'
+        : 'h-16 w-16 shrink-0 rounded-lg object-cover border border-parchment-800/30'
+
+    const placeholderClass = () =>
+      props.size === 'sm'
+        ? 'h-12 w-12 rounded-md bg-parchment-900/40 border border-parchment-800/30'
+        : 'h-16 w-16 shrink-0 rounded-lg bg-parchment-900/40 border border-parchment-800/30'
+
+    return (
+      <>
+        <Show
+          when={auth.canModify(props.course.created_by) && isMissing()}
+          fallback={
+            <A href={`/courses/${String(courseId())}`} class="block">
+              <Show
+                when={props.course.image_url}
+                fallback={<div class={placeholderClass()} aria-hidden />}
+              >
+                <img
+                  src={props.course.image_url ?? ''}
+                  alt=""
+                  width={props.size === 'sm' ? 48 : 64}
+                  height={props.size === 'sm' ? 48 : 64}
+                  loading="lazy"
+                  class={imgClass()}
+                />
+              </Show>
+            </A>
+          }
+        >
+          <MagicButton
+            type="button"
+            variant="ghost"
+            size="sm"
+            iconOnly
+            class={`${boxClass()} p-0 flex items-center justify-center`}
+            aria-label="Generate course image"
+            title="Generate course image"
+            disabled={isLoading()}
+            onClick={() => void handleGenerateCourseImage(courseId())}
+          >
+            Generate Image
+          </MagicButton>
+        </Show>
+      </>
+    )
+  }
+
   return (
     <div class="container mx-auto px-4 py-6 sm:px-6">
       <div class="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
@@ -292,6 +367,11 @@ const Courses: Component = () => {
         when={!coursesData.loading}
         fallback={<div class="text-parchment-200 font-serif p-4">{t().courses.loading}</div>}
       >
+        <Show when={courseImageError()}>
+          <Alert variant="danger" class="mb-4">
+            {courseImageError()}
+          </Alert>
+        </Show>
         {/* Filter section */}
         <div class="mb-6 flex flex-col gap-4 lg:flex-row lg:items-center">
           <div class="w-full max-w-xs sm:max-w-sm lg:w-64">
@@ -362,6 +442,9 @@ const Courses: Component = () => {
             <table class="min-w-full">
               <thead>
                 <tr class="border-b border-parchment-800/30">
+                  <th class="py-3 px-2 w-14 align-middle text-left font-display text-parchment-200">
+                    {/* Album art */}
+                  </th>
                   <SortableHeader field="code" label={t().courses.code} />
                   <SortableHeader field="title" label={t().courses.courseTitle} />
                   <th class="py-3 px-4 align-middle text-left font-display text-parchment-200">
@@ -386,6 +469,9 @@ const Courses: Component = () => {
                 <For each={coursesData()?.items}>
                   {(course: Course) => (
                     <tr class="border-b border-parchment-800/20 hover:bg-arcanum-800/50 transition-colors">
+                      <td class="py-3 px-2 align-middle w-14">
+                        <CourseThumb course={course} size="sm" />
+                      </td>
                       <td class="py-3 px-4 align-middle text-parchment-100">{course.code}</td>
                       <td class="py-3 px-4 align-middle text-parchment-100">
                         <A
@@ -437,7 +523,8 @@ const Courses: Component = () => {
                 <div class="arcane-card p-4">
                   <div class="flex flex-col gap-4">
                     <div class="flex items-start justify-between gap-4">
-                      <div class="flex-1">
+                      <CourseThumb course={course} size="md" />
+                      <div class="flex-1 min-w-0">
                         <div class="flex items-center gap-2 mb-1">
                           <p class="text-xs font-serif uppercase tracking-wide text-parchment-400">
                             {course.code}


### PR DESCRIPTION
## Summary
- Add AI-generated album art for courses (square thumbnail + hero image)
- New course image prompt + prompt refactor to support multiple image prompt modules
- End-to-end wiring: DB fields → job queue → generator/service → API endpoint → web UI

## Changes
- **DB/models**: add `courses.image_url` + `courses.image_created_with` (migration + models/types)
- **Prompts**: split prompts into `professor_image.py` and `course_image.py`
- **Backend**:
  - `ImageService.generate_course_image`
  - `CourseGeneratorService.generate_and_set_course_image`
  - new job kind: `generate_course_image` + enqueue helper
  - auto-enqueue course image on course creation
  - API: `POST /api/v1/courses/{course_id}/generate-image` (owner/admin only, coin cost)
- **Web**:
  - course list shows album art thumbnails; if missing and user can modify, shows icon-only generate button
  - course detail shows hero art and generate/regenerate button (owner/admin only)

## Test plan
- `hatch run pytest tests/api/test_courses.py`
- `hatch run pytest tests/unit/prompts/test_course_image_prompt.py tests/unit/services/test_course_generator_image.py`
- `cd web && pnpm lint && pnpm exec tsc --noEmit`

## Notes
- Integration tests require the new migration applied to the target test DB.

Made with [Cursor](https://cursor.com)