### PR TITLE
Add OG share URLs for richer previews

### DIFF
--- a/artificial_u/api/app.py
+++ b/artificial_u/api/app.py
@@ -25,6 +25,7 @@ from artificial_u.api.routers.preferences import router as preferences_router
 from artificial_u.api.routers.professors import router as professors_router
 from artificial_u.api.routers.quickstart import router as quickstart_router
 from artificial_u.api.routers.search import router as search_router
+from artificial_u.api.routers.share import router as share_router
 from artificial_u.api.routers.stats import router as stats_router
 from artificial_u.api.routers.students import router as students_router
 from artificial_u.api.routers.topics import course_topics_router
@@ -130,6 +131,8 @@ def create_application() -> FastAPI:
     app.include_router(quickstart_router, prefix="/api/v1")
     app.include_router(search_router, prefix="/api/v1")
     app.include_router(stats_router, prefix="/api/v1")
+    # Share / unfurl endpoints for rich link previews (OG/Twitter tags)
+    app.include_router(share_router)
 
     return app
 

--- a/artificial_u/api/routers/share.py
+++ b/artificial_u/api/routers/share.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import html
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse
+
+from artificial_u.api.config import Settings, get_settings
+from artificial_u.api.dependencies import get_repository_factory
+from artificial_u.models.repositories import RepositoryFactory
+
+router = APIRouter(tags=["Share"])
+
+
+def _public_web_base_url(request: Request, settings: Settings) -> str:
+    base = (settings.PUBLIC_WEB_URL or "").strip()
+    if base:
+        return base.rstrip("/")
+    return str(request.base_url).rstrip("/")
+
+
+def _default_og_image_url(base: str, settings: Settings) -> str:
+    if settings.PUBLIC_OG_DEFAULT_IMAGE_URL:
+        return settings.PUBLIC_OG_DEFAULT_IMAGE_URL
+    return f"{base}/icons/icon-512x512.png"
+
+
+def _share_html(
+    *,
+    title: str,
+    description: str,
+    canonical_url: str,
+    image_url: str,
+    redirect_to: str,
+) -> str:
+    t = html.escape(title)
+    d = html.escape(description)
+    u = html.escape(canonical_url)
+    img = html.escape(image_url)
+    dest = html.escape(redirect_to)
+
+    # Notes:
+    # - Link unfurlers (Slack/iMessage/Discord/etc) fetch HTML and read <meta> tags.
+    # - They do not execute JS, so the OG/Twitter tags must be present in the HTML response.
+    return f"""<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{t}</title>
+
+    <link rel="canonical" href="{u}" />
+
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content="{t}" />
+    <meta property="og:description" content="{d}" />
+    <meta property="og:url" content="{u}" />
+    <meta property="og:image" content="{img}" />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="{t}" />
+    <meta name="twitter:description" content="{d}" />
+    <meta name="twitter:image" content="{img}" />
+
+    <meta http-equiv="refresh" content="0; url={dest}" />
+  </head>
+  <body>
+    <p>
+      Redirecting to <a href="{dest}">the content</a>…
+    </p>
+  </body>
+</html>
+"""
+
+
+def _truncate_description(text: Optional[str], *, fallback: str, max_len: int = 240) -> str:
+    raw = (text or "").strip()
+    if not raw:
+        return fallback
+    if len(raw) <= max_len:
+        return raw
+    return f"{raw[: max_len - 1].rstrip()}…"
+
+
+@router.get("/share/courses/{course_id}", response_class=HTMLResponse)
+def share_course(
+    request: Request,
+    course_id: int,
+    repository_factory: RepositoryFactory = Depends(get_repository_factory),
+    settings: Settings = Depends(get_settings),
+):
+    base = _public_web_base_url(request, settings)
+
+    course = repository_factory.course.get(course_id)
+    if not course:
+        url = f"{base}/courses/{course_id}"
+        return HTMLResponse(
+            _share_html(
+                title="Course not found",
+                description="This course may have been removed.",
+                canonical_url=url,
+                image_url=_default_og_image_url(base, settings),
+                redirect_to=url,
+            ),
+            status_code=404,
+            headers={"Cache-Control": "no-store"},
+        )
+
+    web_url = f"{base}/courses/{course_id}"
+    share_url = f"{base}/share/courses/{course_id}"
+    title = f"{course.code}: {course.title}"
+    description = _truncate_description(
+        course.description,
+        fallback="Explore this course on ArtificialU.",
+    )
+    image_url = course.image_url or _default_og_image_url(base, settings)
+
+    return HTMLResponse(
+        _share_html(
+            title=title,
+            description=description,
+            canonical_url=web_url,
+            image_url=image_url,
+            redirect_to=web_url,
+        ),
+        headers={
+            "Cache-Control": "public, max-age=300",
+            "X-Share-Url": share_url,
+        },
+    )
+
+
+@router.get("/share/courses/{course_id}/topics/{topic_id}", response_class=HTMLResponse)
+def share_topic(
+    request: Request,
+    course_id: int,
+    topic_id: int,
+    repository_factory: RepositoryFactory = Depends(get_repository_factory),
+    settings: Settings = Depends(get_settings),
+):
+    base = _public_web_base_url(request, settings)
+
+    course = repository_factory.course.get(course_id)
+    topic = repository_factory.topic.get(topic_id)
+    if not course or not topic or topic.course_id != course_id:
+        url = f"{base}/courses/{course_id}/topics/{topic_id}"
+        return HTMLResponse(
+            _share_html(
+                title="Topic not found",
+                description="This topic may have been removed.",
+                canonical_url=url,
+                image_url=_default_og_image_url(base, settings),
+                redirect_to=url,
+            ),
+            status_code=404,
+            headers={"Cache-Control": "no-store"},
+        )
+
+    web_url = f"{base}/courses/{course_id}/topics/{topic_id}"
+    title = f"{course.code} · Week {topic.week}" + (
+        f" Topic {topic.order}" if topic.order > 1 else ""
+    )
+    title = f"{title}: {topic.title}"
+    description = _truncate_description(
+        str(topic.content) if topic.content is not None else None,
+        fallback=f"{course.code}: {course.title}",
+    )
+    image_url = course.image_url or _default_og_image_url(base, settings)
+
+    return HTMLResponse(
+        _share_html(
+            title=title,
+            description=description,
+            canonical_url=web_url,
+            image_url=image_url,
+            redirect_to=web_url,
+        ),
+        headers={"Cache-Control": "public, max-age=300"},
+    )
+
+
+@router.get("/share/courses/{course_id}/lectures/{lecture_id}", response_class=HTMLResponse)
+def share_lecture(
+    request: Request,
+    course_id: int,
+    lecture_id: int,
+    repository_factory: RepositoryFactory = Depends(get_repository_factory),
+    settings: Settings = Depends(get_settings),
+):
+    base = _public_web_base_url(request, settings)
+
+    course = repository_factory.course.get(course_id)
+    lecture = repository_factory.lecture.get(lecture_id)
+    if not course or not lecture or lecture.course_id != course_id:
+        url = f"{base}/courses/{course_id}/lectures/{lecture_id}"
+        return HTMLResponse(
+            _share_html(
+                title="Lecture not found",
+                description="This lecture may have been removed.",
+                canonical_url=url,
+                image_url=_default_og_image_url(base, settings),
+                redirect_to=url,
+            ),
+            status_code=404,
+            headers={"Cache-Control": "no-store"},
+        )
+
+    topic = repository_factory.topic.get(lecture.topic_id) if lecture.topic_id else None
+
+    web_url = f"{base}/courses/{course_id}/lectures/{lecture_id}"
+    title_bits = [course.code, lecture.title]
+    if topic:
+        title_bits.insert(1, f"Week {topic.week}")
+    title = " · ".join(title_bits)
+
+    description = _truncate_description(
+        lecture.summary,
+        fallback=(topic.title if topic else f"{course.code}: {course.title}"),
+    )
+    image_url = course.image_url or _default_og_image_url(base, settings)
+
+    return HTMLResponse(
+        _share_html(
+            title=title,
+            description=description,
+            canonical_url=web_url,
+            image_url=image_url,
+            redirect_to=web_url,
+        ),
+        headers={"Cache-Control": "public, max-age=300"},
+    )
+
+
+@router.get("/share/professors/{professor_id}", response_class=HTMLResponse)
+def share_professor(
+    request: Request,
+    professor_id: int,
+    repository_factory: RepositoryFactory = Depends(get_repository_factory),
+    settings: Settings = Depends(get_settings),
+):
+    base = _public_web_base_url(request, settings)
+
+    professor = repository_factory.professor.get(professor_id)
+    if not professor:
+        url = f"{base}/professors/{professor_id}"
+        return HTMLResponse(
+            _share_html(
+                title="Professor not found",
+                description="This professor may have been removed.",
+                canonical_url=url,
+                image_url=_default_og_image_url(base, settings),
+                redirect_to=url,
+            ),
+            status_code=404,
+            headers={"Cache-Control": "no-store"},
+        )
+
+    web_url = f"{base}/professors/{professor_id}"
+    title = professor.name if professor.title is None else f"{professor.name} · {professor.title}"
+    description = _truncate_description(
+        professor.specialization or professor.background or professor.description,
+        fallback="Meet this professor on ArtificialU.",
+    )
+    image_url = professor.image_url or _default_og_image_url(base, settings)
+
+    return HTMLResponse(
+        _share_html(
+            title=title,
+            description=description,
+            canonical_url=web_url,
+            image_url=image_url,
+            redirect_to=web_url,
+        ),
+        headers={"Cache-Control": "public, max-age=300"},
+    )

--- a/artificial_u/config/settings.py
+++ b/artificial_u/config/settings.py
@@ -70,6 +70,11 @@ class Settings(BaseSettings):
         ]
     )
 
+    # Public URLs (used for OG tags, canonical links, redirects)
+    # These should be set in production so share/unfurl pages generate stable absolute URLs.
+    PUBLIC_WEB_URL: str = "https://artificial-u.com"
+    PUBLIC_OG_DEFAULT_IMAGE_URL: Optional[str] = None
+
     # Database settings
     DATABASE_URL: str = DEFAULT_DB_URL
 

--- a/web/src/components/ui/ShareButton.jsx
+++ b/web/src/components/ui/ShareButton.jsx
@@ -1,0 +1,68 @@
+import { Share2 } from 'lucide-solid'
+import { createSignal, Show } from 'solid-js'
+import { Button } from './Button.jsx'
+
+export const ShareButton = (props) => {
+  const [status, setStatus] = createSignal('idle') // idle | copied | failed
+
+  const copyToClipboard = async (text) => {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text)
+      return
+    }
+
+    // Fallback for older browsers / non-secure contexts
+    const el = document.createElement('textarea')
+    el.value = text
+    el.setAttribute('readonly', '')
+    el.style.position = 'absolute'
+    el.style.left = '-9999px'
+    document.body.appendChild(el)
+    el.select()
+    document.execCommand('copy')
+    document.body.removeChild(el)
+  }
+
+  const onShare = async () => {
+    const url = props.url
+    if (!url) return
+
+    try {
+      // Prefer native share sheet when available
+      if (navigator.share) {
+        await navigator.share({
+          url,
+          title: props.title,
+          text: props.text,
+        })
+        setStatus('idle')
+        return
+      }
+
+      await copyToClipboard(url)
+      setStatus('copied')
+      setTimeout(() => setStatus('idle'), 1500)
+    } catch {
+      setStatus('failed')
+      setTimeout(() => setStatus('idle'), 1500)
+    }
+  }
+
+  return (
+    <Button
+      variant={props.variant ?? 'outline'}
+      size={props.size ?? 'sm'}
+      class={props.class}
+      onClick={() => void onShare()}
+    >
+      <Share2 class="h-4 w-4" />
+      <span class="ml-2">
+        <Show when={status() === 'copied'} fallback={props.label ?? 'Share'}>
+          Copied
+        </Show>
+        <Show when={status() === 'failed'}>Failed</Show>
+      </span>
+    </Button>
+  )
+}
+

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -12,6 +12,7 @@ export { LoadingSpinner } from './LoadingSpinner.jsx'
 export { MagicButton } from './MagicButton.jsx'
 export { default as MetadataInfo } from './MetadataInfo.jsx'
 export { default as NumberInput } from './NumberInput.jsx'
+export { ShareButton } from './ShareButton.jsx'
 export type { SelectOption } from './Select.jsx'
 // Ensure SelectOption is also exported if it's meant to be used externally
 export { default as Select } from './Select.jsx'

--- a/web/src/pages/CourseDetail.tsx
+++ b/web/src/pages/CourseDetail.tsx
@@ -15,7 +15,7 @@ import { useAuth } from '../auth/AuthProvider'
 import { RequireRole } from '../auth/RequireRole'
 import CourseForm from '../components/courses/CourseForm.jsx'
 import type { CourseFormData } from '../components/courses/types.jsx'
-import { Alert, Button, MagicButton, MetadataInfo } from '../components/ui'
+import { Alert, Button, MagicButton, MetadataInfo, ShareButton } from '../components/ui'
 import { useTranslations } from '../i18n'
 import { useAudioPlayer } from '../utils/audio-player-context.jsx'
 import { createJobTracker, getJobMessage } from '../utils/job-management.js'
@@ -498,6 +498,7 @@ const CourseDetail: Component = () => {
                   </A>
                   <Show when={!isEditing()}>
                     <div class="flex flex-wrap items-center gap-2 sm:justify-end">
+                      <ShareButton url={`${window.location.origin}/share/courses/${String(courseId)}`} />
                       <Show
                         when={auth.canModify(course().created_by) && course().status === 'hidden'}
                       >

--- a/web/src/pages/LectureDetail.tsx
+++ b/web/src/pages/LectureDetail.tsx
@@ -17,7 +17,14 @@ import type { Lecture, LectureUpdate } from '../api/types.js'
 import { useAuth } from '../auth/AuthProvider'
 import { RequireRole } from '../auth/RequireRole'
 import { LectureForm } from '../components/lectures/LectureForm.jsx'
-import { Alert, Button, ConfirmationModal, MagicButton, MetadataInfo } from '../components/ui'
+import {
+  Alert,
+  Button,
+  ConfirmationModal,
+  MagicButton,
+  MetadataInfo,
+  ShareButton,
+} from '../components/ui'
 import { useTranslations } from '../i18n/index.js'
 import { useAudioPlayer } from '../utils/audio-player-context.jsx'
 import { getJobEventHub } from '../utils/job-events-hub.js'
@@ -505,6 +512,12 @@ const LectureDetail = () => {
                         {t().lectureDetail.backToTopic}
                       </A>
                     </div>
+
+                    <ShareButton
+                      url={`${window.location.origin}/share/courses/${String(
+                        courseId()
+                      )}/lectures/${String(lectureId())}`}
+                    />
 
                     {/* Prev/Next Topic navigation */}
                     <Show when={topicsList() && topic()}>

--- a/web/src/pages/ProfessorDetail.tsx
+++ b/web/src/pages/ProfessorDetail.tsx
@@ -1,12 +1,21 @@
 import { A } from '@solidjs/router'
 import ProfessorDetail from '../components/professors/ProfessorDetail'
+import { ShareButton } from '../components/ui'
 
 export default function ProfessorDetailPage() {
   return (
     <main class="container mx-auto p-4">
-      <A href="/professors" class="text-accent hover:text-accent/80 mb-4 inline-block">
-        &larr; Back to Professors
-      </A>
+      <div class="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <A href="/professors" class="text-accent hover:text-accent/80 inline-block">
+          &larr; Back to Professors
+        </A>
+        <ShareButton
+          url={`${window.location.origin}${window.location.pathname}`.replace(
+            '/professors/',
+            '/share/professors/'
+          )}
+        />
+      </div>
       <ProfessorDetail />
     </main>
   )

--- a/web/src/pages/TopicDetail.tsx
+++ b/web/src/pages/TopicDetail.tsx
@@ -8,7 +8,7 @@ import { RequireRole } from '../auth/RequireRole'
 import { LectureSection } from '../components/lectures/LectureSection.jsx'
 import { TopicContentRenderer } from '../components/topics/TopicContentRenderer.jsx'
 import { TopicForm } from '../components/topics/TopicForm.jsx'
-import { Alert, Button, MetadataInfo } from '../components/ui'
+import { Alert, Button, MetadataInfo, ShareButton } from '../components/ui'
 import { useTranslations } from '../i18n/index.js'
 import { createJobTracker, getJobMessage } from '../utils/job-management.js'
 
@@ -255,12 +255,19 @@ const TopicDetail = () => {
                 <div>
                   {/* Breadcrumb navigation */}
                   <div class="mb-6">
-                    <A
-                      href={`/courses/${String(courseId())}`}
-                      class="text-mystic-500 hover:text-mystic-300 whitespace-nowrap"
-                    >
-                      ← {t().courseDetail.backToCourse}
-                    </A>
+                    <div class="flex flex-wrap items-center justify-between gap-3">
+                      <A
+                        href={`/courses/${String(courseId())}`}
+                        class="text-mystic-500 hover:text-mystic-300 whitespace-nowrap"
+                      >
+                        ← {t().courseDetail.backToCourse}
+                      </A>
+                      <ShareButton
+                        url={`${window.location.origin}/share/courses/${String(
+                          courseId()
+                        )}/topics/${String(topicId())}`}
+                      />
+                    </div>
                   </div>
 
                   {/* Course context */}


### PR DESCRIPTION
## Summary
- Add server-rendered share/unfurl pages with Open Graph + Twitter card meta tags for courses, topics, lectures, and professors.
- Add UI share buttons on detail pages that copy/share the new share URLs.

## Test plan
- Visit a share URL like `/share/courses/75` and confirm OG/Twitter meta tags are present in the HTML.
- Confirm it redirects to the canonical app URL.
- Share a `/share/...` link in Slack/Discord/iMessage and verify a rich preview renders.

Made with [Cursor](https://cursor.com)