### PR TITLE
follow-up job chains and improved polling

### DIFF
--- a/alembic/versions/d7e8f9a0b1c2_add_parent_job_id_to_jobs.py
+++ b/alembic/versions/d7e8f9a0b1c2_add_parent_job_id_to_jobs.py
@@ -1,0 +1,29 @@
+"""add parent_job_id to jobs
+
+Revision ID: d7e8f9a0b1c2
+Revises: c4d5e6f7a8b9
+Create Date: 2026-04-29
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "d7e8f9a0b1c2"
+down_revision = "c4d5e6f7a8b9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "jobs",
+        sa.Column("parent_job_id", sa.Integer(), sa.ForeignKey("jobs.id"), nullable=True),
+    )
+    op.create_index("idx_jobs_parent_job_id", "jobs", ["parent_job_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_jobs_parent_job_id", table_name="jobs")
+    op.drop_column("jobs", "parent_job_id")

--- a/artificial_u/api/routers/jobs.py
+++ b/artificial_u/api/routers/jobs.py
@@ -44,6 +44,7 @@ def _job_row_response(r) -> dict:
         "payload": r.payload,
         "result": r.result,
         "duration_ms": _duration_ms_from_result(r.result),
+        "parent_job_id": getattr(r, "parent_job_id", None),
     }
 
 
@@ -135,6 +136,7 @@ def list_jobs(
     lecture_id: Optional[int] = None,
     topic_id: Optional[int] = None,
     course_id: Optional[int] = None,
+    parent_id: Optional[int] = None,
     repository_factory: RepositoryFactory = Depends(get_repository_factory),
 ):
     repo = repository_factory.job
@@ -145,6 +147,7 @@ def list_jobs(
         lecture_id=lecture_id,
         topic_id=topic_id,
         course_id=course_id,
+        parent_id=parent_id,
     )
     return [_job_row_response(r) for r in rows]
 
@@ -227,21 +230,19 @@ def get_job(
     row = repo.get(job_id)
     if not row:
         raise HTTPException(404, "job not found")
-    return {
-        "id": row.id,
-        "kind": row.kind,
-        "payload": row.payload,
-        "status": row.status,
-        "priority": row.priority,
-        "run_after": row.run_after,
-        "attempts": row.attempts,
-        "max_attempts": row.max_attempts,
-        "last_error": row.last_error,
-        "result": row.result,
-        "duration_ms": _duration_ms_from_result(row.result),
-        "created_at": row.created_at,
-        "updated_at": row.updated_at,
-    }
+    return _job_row_response(row)
+
+
+@router.get("/{job_id}/children", dependencies=[Depends(require_auth)])
+def get_job_children(
+    job_id: int,
+    repository_factory: RepositoryFactory = Depends(get_repository_factory),
+):
+    repo = repository_factory.job
+    if not repo.get(job_id):
+        raise HTTPException(404, "job not found")
+    rows = repo.list(parent_id=job_id, limit=200)
+    return [_job_row_response(r) for r in rows]
 
 
 @router.post("/{job_id}/cancel", dependencies=[Depends(require_auth)])

--- a/artificial_u/api/worker.py
+++ b/artificial_u/api/worker.py
@@ -313,7 +313,7 @@ class Worker:
             self.logger.debug("Dispatching job to handler", extra={**log_base, "job_id": job_id})
             await self._publish_event(job_id, kind, "running", payload)
             result = await asyncio.wait_for(
-                self.job_service.dispatch(kind, payload),
+                self.job_service.dispatch(kind, payload, parent_job_id=job_id),
                 timeout=self.settings.JOB_EXECUTION_TIMEOUT_SEC,
             )
             return result

--- a/artificial_u/models/database.py
+++ b/artificial_u/models/database.py
@@ -226,12 +226,14 @@ class JobModel(Base):
     max_attempts = Column(Integer, nullable=False, default=5)
     last_error = Column(Text, nullable=True)
     result = Column(JSONB, nullable=True)
+    parent_job_id = Column(Integer, ForeignKey("jobs.id"), nullable=True)
     created_at = Column(DateTime, nullable=False, default=datetime.now)
     updated_at = Column(DateTime, nullable=False, default=datetime.now)
 
     __table_args__ = (
         Index("idx_jobs_status_priority_runafter", "status", "priority", "run_after"),
         Index("idx_jobs_status_updatedat", "status", "updated_at"),
+        Index("idx_jobs_parent_job_id", "parent_job_id"),
     )
 
 

--- a/artificial_u/models/repositories/job.py
+++ b/artificial_u/models/repositories/job.py
@@ -24,6 +24,7 @@ class JobRepository(BaseRepository):
         priority: int = 0,
         run_after: Optional[dt.datetime] = None,
         max_attempts: int = 2,
+        parent_job_id: Optional[int] = None,
     ) -> JobModel:
         run_after = run_after or self._now()
         with self.get_session() as session:
@@ -34,6 +35,7 @@ class JobRepository(BaseRepository):
                 priority=priority,
                 run_after=run_after,
                 max_attempts=max_attempts,
+                parent_job_id=parent_job_id,
             )
             session.add(job)
             session.commit()
@@ -53,6 +55,7 @@ class JobRepository(BaseRepository):
         lecture_id: Optional[int] = None,
         topic_id: Optional[int] = None,
         course_id: Optional[int] = None,
+        parent_id: Optional[int] = None,
     ) -> List[JobModel]:
         with self.get_session() as session:
             stmt = select(JobModel)
@@ -60,6 +63,8 @@ class JobRepository(BaseRepository):
                 stmt = stmt.where(JobModel.status == status)
             if kind:
                 stmt = stmt.where(JobModel.kind == kind)
+            if parent_id is not None:
+                stmt = stmt.where(JobModel.parent_job_id == parent_id)
 
             # JSONB payload filters (best-effort on Postgres)
             if lecture_id is not None:

--- a/artificial_u/services/course_service.py
+++ b/artificial_u/services/course_service.py
@@ -66,6 +66,7 @@ class CourseService:
         description: Optional[str] = None,
         created_by: Optional[int] = None,
         created_with: Optional[str] = None,
+        parent_job_id: Optional[int] = None,
     ) -> Tuple[Course, Professor]:
         """
         Create a new course with optional smart selection for department/professor.
@@ -117,7 +118,7 @@ class CourseService:
         course.created_with = created_with
 
         # Save course
-        return self._save_course(course, professor, code)
+        return self._save_course(course, professor, code, parent_job_id=parent_job_id)
 
     async def _resolve_department_id(
         self, department_id: Optional[int], course_attributes: dict
@@ -184,7 +185,9 @@ class CourseService:
             lectures_per_week=lectures_per_week,
         )
 
-    def _save_course(self, course: Course, professor, code: str) -> Tuple[Course, Any]:
+    def _save_course(
+        self, course: Course, professor, code: str, *, parent_job_id: Optional[int] = None
+    ) -> Tuple[Course, Any]:
         """Save course to database with error handling."""
         try:
             created_course = self.repository_factory.course.create(course)
@@ -192,7 +195,9 @@ class CourseService:
             if self.job_enqueue_service:
                 try:
                     if not getattr(created_course, "image_url", None):
-                        self.job_enqueue_service.enqueue_course_image_generation(created_course.id)
+                        self.job_enqueue_service.enqueue_course_image_generation(
+                            created_course.id, parent_job_id=parent_job_id
+                        )
                     else:
                         self.logger.debug(
                             "Skipping course image job on create: course %s already has image",

--- a/artificial_u/services/job_enqueue_service.py
+++ b/artificial_u/services/job_enqueue_service.py
@@ -6,6 +6,7 @@ avoiding duplication across different domain services.
 """
 
 import logging
+from typing import Optional
 
 from artificial_u.config import get_settings
 from artificial_u.models.repositories.factory import RepositoryFactory
@@ -20,42 +21,29 @@ class JobEnqueueService:
         repository_factory: RepositoryFactory,
         logger=None,
     ):
-        """
-        Initialize the job enqueue service.
-
-        Args:
-            repository_factory: Repository factory instance
-            logger: Optional logger instance
-        """
         self.repository_factory = repository_factory
         self.logger = logger or logging.getLogger(__name__)
 
     def enqueue_professor_image_generation(
-        self, professor_id: int, aspect_ratio: str = "1:1"
-    ) -> None:
-        """
-        Enqueue a background job to generate an image for the professor.
-
-        Args:
-            professor_id: The ID of the professor
-            aspect_ratio: The desired aspect ratio for the image
-
-        Raises:
-            DatabaseError: If job enqueueing fails
-        """
+        self,
+        professor_id: int,
+        aspect_ratio: str = "1:1",
+        *,
+        parent_job_id: Optional[int] = None,
+    ) -> int:
+        """Enqueue a background job to generate an image for the professor."""
         try:
-            job_repo = self.repository_factory.job
-            job = job_repo.create(
+            job = self.repository_factory.job.create(
                 kind="generate_professor_image",
-                payload={
-                    "professor_id": professor_id,
-                    "aspect_ratio": aspect_ratio,
-                },
+                payload={"professor_id": professor_id, "aspect_ratio": aspect_ratio},
+                parent_job_id=parent_job_id,
             )
-            job_id = job.id
             self.logger.info(
-                f"Enqueued professor image generation job {job_id} for professor {professor_id}"
+                "Enqueued professor image generation job %d for professor %d",
+                job.id,
+                professor_id,
             )
+            return job.id
         except Exception as e:
             error_msg = (
                 f"Failed to enqueue professor image generation job "
@@ -64,169 +52,160 @@ class JobEnqueueService:
             self.logger.error(error_msg, exc_info=True)
             raise DatabaseError(error_msg) from e
 
-    def enqueue_course_image_generation(self, course_id: int, aspect_ratio: str = "1:1") -> None:
-        """
-        Enqueue a background job to generate album art for a course.
-
-        Args:
-            course_id: The ID of the course
-            aspect_ratio: The desired aspect ratio for the image
-
-        Raises:
-            DatabaseError: If job enqueueing fails
-        """
+    def enqueue_course_image_generation(
+        self,
+        course_id: int,
+        aspect_ratio: str = "1:1",
+        *,
+        parent_job_id: Optional[int] = None,
+    ) -> int:
+        """Enqueue a background job to generate album art for a course."""
         try:
-            job_repo = self.repository_factory.job
-            job = job_repo.create(
+            job = self.repository_factory.job.create(
                 kind="generate_course_image",
-                payload={
-                    "course_id": course_id,
-                    "aspect_ratio": aspect_ratio,
-                },
+                payload={"course_id": course_id, "aspect_ratio": aspect_ratio},
+                parent_job_id=parent_job_id,
             )
-            job_id = job.id
             self.logger.info(
-                f"Enqueued course image generation job {job_id} for course {course_id}"
+                "Enqueued course image generation job %d for course %d", job.id, course_id
             )
+            return job.id
         except Exception as e:
             error_msg = f"Failed to enqueue course image generation job for course {course_id}: {e}"
             self.logger.error(error_msg, exc_info=True)
             raise DatabaseError(error_msg) from e
 
     def enqueue_lecture_summary_generation(
-        self, lecture_id: int, *, topic_id: int | None = None
-    ) -> None:
-        """
-        Enqueue a background job to generate a lecture summary.
-
-        Args:
-            lecture_id: The ID of the lecture
-
-        Raises:
-            DatabaseError: If job enqueueing fails
-        """
+        self,
+        lecture_id: int,
+        *,
+        topic_id: Optional[int] = None,
+        parent_job_id: Optional[int] = None,
+    ) -> Optional[int]:
+        """Enqueue a background job to generate a lecture summary."""
         if get_settings().testing:
             self.logger.debug("Skipping lecture summary job enqueue: running in test mode")
-            return
+            return None
 
         try:
-            job_repo = self.repository_factory.job
-            payload = {"lecture_id": lecture_id}
+            payload: dict = {"lecture_id": lecture_id}
             if topic_id is not None:
                 payload["topic_id"] = topic_id
-            job = job_repo.create(kind="generate_lecture_summary", payload=payload)
-            job_id = job.id
-            self.logger.info(f"Enqueued lecture summary job {job_id} for lecture {lecture_id}")
+            job = self.repository_factory.job.create(
+                kind="generate_lecture_summary",
+                payload=payload,
+                parent_job_id=parent_job_id,
+            )
+            self.logger.info("Enqueued lecture summary job %d for lecture %d", job.id, lecture_id)
+            return job.id
         except Exception as e:
             error_msg = f"Failed to enqueue lecture summary job for lecture {lecture_id}: {e}"
             self.logger.error(error_msg, exc_info=True)
             raise DatabaseError(error_msg) from e
 
     def enqueue_lecture_audio_generation(
-        self, lecture_id: int, *, topic_id: int | None = None
-    ) -> None:
-        """
-        Enqueue a background job to generate lecture audio.
-
-        Args:
-            lecture_id: The ID of the lecture
-
-        Raises:
-            DatabaseError: If job enqueueing fails
-        """
+        self,
+        lecture_id: int,
+        *,
+        topic_id: Optional[int] = None,
+        parent_job_id: Optional[int] = None,
+    ) -> Optional[int]:
+        """Enqueue a background job to generate lecture audio."""
         if get_settings().testing:
             self.logger.debug("Skipping lecture audio job enqueue: running in test mode")
-            return
+            return None
 
         try:
-            job_repo = self.repository_factory.job
-            payload = {"lecture_id": lecture_id}
+            payload: dict = {"lecture_id": lecture_id}
             if topic_id is not None:
                 payload["topic_id"] = topic_id
-            job = job_repo.create(kind="generate_lecture_audio", payload=payload)
-            job_id = job.id
-            self.logger.info(f"Enqueued lecture audio job {job_id} for lecture {lecture_id}")
+            job = self.repository_factory.job.create(
+                kind="generate_lecture_audio",
+                payload=payload,
+                parent_job_id=parent_job_id,
+            )
+            self.logger.info("Enqueued lecture audio job %d for lecture %d", job.id, lecture_id)
+            return job.id
         except Exception as e:
             error_msg = f"Failed to enqueue lecture audio job for lecture {lecture_id}: {e}"
             self.logger.error(error_msg, exc_info=True)
             raise DatabaseError(error_msg) from e
 
     def enqueue_lecture_timeline_generation(
-        self, lecture_id: int, *, topic_id: int | None = None
-    ) -> None:
-        """
-        Enqueue a background job to generate a lecture timeline (forced alignment).
-
-        Args:
-            lecture_id: The ID of the lecture
-
-        Raises:
-            DatabaseError: If job enqueueing fails
-        """
+        self,
+        lecture_id: int,
+        *,
+        topic_id: Optional[int] = None,
+        parent_job_id: Optional[int] = None,
+    ) -> Optional[int]:
+        """Enqueue a background job to generate a lecture timeline (forced alignment)."""
         if get_settings().testing:
             self.logger.debug("Skipping lecture timeline job enqueue: running in test mode")
-            return
+            return None
 
         try:
-            job_repo = self.repository_factory.job
-            payload = {"lecture_id": lecture_id}
+            payload: dict = {"lecture_id": lecture_id}
             if topic_id is not None:
                 payload["topic_id"] = topic_id
-            job = job_repo.create(kind="generate_lecture_timeline", payload=payload)
-            job_id = job.id
-            self.logger.info(f"Enqueued lecture timeline job {job_id} for lecture {lecture_id}")
+            job = self.repository_factory.job.create(
+                kind="generate_lecture_timeline",
+                payload=payload,
+                parent_job_id=parent_job_id,
+            )
+            self.logger.info("Enqueued lecture timeline job %d for lecture %d", job.id, lecture_id)
+            return job.id
         except Exception as e:
             error_msg = f"Failed to enqueue lecture timeline job for lecture {lecture_id}: {e}"
             self.logger.error(error_msg, exc_info=True)
             raise DatabaseError(error_msg) from e
 
-    def enqueue_lecture_images_generation(self, lecture_id: int) -> None:
-        """
-        Enqueue a background job to generate a lecture images timeline + slide images.
-
-        Admin-only in the API layer.
-        """
+    def enqueue_lecture_images_generation(
+        self,
+        lecture_id: int,
+        *,
+        parent_job_id: Optional[int] = None,
+    ) -> Optional[int]:
+        """Enqueue a background job to generate a lecture images timeline + slide images."""
         if get_settings().testing:
             self.logger.debug("Skipping lecture images job enqueue: running in test mode")
-            return
+            return None
 
         try:
-            job_repo = self.repository_factory.job
-            payload = {"lecture_id": lecture_id}
-            job = job_repo.create(kind="generate_lecture_images", payload=payload)
-            job_id = job.id
-            self.logger.info(f"Enqueued lecture images job {job_id} for lecture {lecture_id}")
+            job = self.repository_factory.job.create(
+                kind="generate_lecture_images",
+                payload={"lecture_id": lecture_id},
+                parent_job_id=parent_job_id,
+            )
+            self.logger.info("Enqueued lecture images job %d for lecture %d", job.id, lecture_id)
+            return job.id
         except Exception as e:
             error_msg = f"Failed to enqueue lecture images job for lecture {lecture_id}: {e}"
             self.logger.error(error_msg, exc_info=True)
             raise DatabaseError(error_msg) from e
 
-    def enqueue_topics_generation(self, course_id: int, created_by: int = None) -> None:
-        """
-        Enqueue a background job to generate topics for a course.
-
-        Args:
-            course_id: The ID of the course
-            created_by: Optional student ID who triggered the generation
-
-        Raises:
-            DatabaseError: If job enqueueing fails
-        """
+    def enqueue_topics_generation(
+        self,
+        course_id: int,
+        created_by: Optional[int] = None,
+        *,
+        parent_job_id: Optional[int] = None,
+    ) -> Optional[int]:
+        """Enqueue a background job to generate topics for a course."""
         if get_settings().testing:
             self.logger.debug("Skipping topics generation job enqueue: running in test mode")
-            return
+            return None
 
         try:
-            job_repo = self.repository_factory.job
-            payload = {"course_id": course_id}
+            payload: dict = {"course_id": course_id}
             if created_by is not None:
                 payload["created_by"] = created_by
-            job = job_repo.create(
+            job = self.repository_factory.job.create(
                 kind="generate_topics_for_course",
                 payload=payload,
+                parent_job_id=parent_job_id,
             )
-            job_id = job.id
-            self.logger.info(f"Enqueued topics generation job {job_id} for course {course_id}")
+            self.logger.info("Enqueued topics generation job %d for course %d", job.id, course_id)
+            return job.id
         except Exception as e:
             error_msg = f"Failed to enqueue topics generation job for course {course_id}: {e}"
             self.logger.error(error_msg, exc_info=True)

--- a/artificial_u/services/job_service.py
+++ b/artificial_u/services/job_service.py
@@ -46,7 +46,12 @@ class JobService:
 
     # ---- Public API ----
 
-    async def dispatch(self, kind: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    async def dispatch(
+        self,
+        kind: str,
+        payload: Dict[str, Any],
+        parent_job_id: Optional[int] = None,
+    ) -> Dict[str, Any]:
         """
         Route a job by kind to the appropriate handler. Returns a JSON-serializable result.
         """
@@ -61,7 +66,7 @@ class JobService:
 
         self.logger.debug(f"Found handler for kind '{kind}', executing...")
         try:
-            result = await handler(payload)
+            result = await handler(payload, parent_job_id=parent_job_id)
             self.logger.info(f"Job kind '{kind}' completed successfully")
             return result
         except Exception as e:
@@ -77,7 +82,11 @@ class JobService:
         return base + jitter
 
     def _build_lecture_slide_chain(
-        self, slide_payloads: list[Dict[str, Any]], *, slide_priority: int
+        self,
+        slide_payloads: list[Dict[str, Any]],
+        *,
+        slide_priority: int,
+        chain_parent_job_id: Optional[int] = None,
     ) -> Optional[Dict[str, Any]]:
         """
         Build a linked list of slide payloads so each slide can enqueue its successor
@@ -87,6 +96,8 @@ class JobService:
         for slide_payload in reversed(slide_payloads):
             current = dict(slide_payload)
             current["slide_priority"] = slide_priority
+            if chain_parent_job_id is not None:
+                current["chain_parent_job_id"] = chain_parent_job_id
             if next_payload is not None:
                 current["next_slide_payload"] = next_payload
             next_payload = current
@@ -110,12 +121,14 @@ class JobService:
         if result.get("status") not in {"done", "failed", "skipped"}:
             return None
 
+        chain_parent_job_id = payload.get("chain_parent_job_id")
         row = self.repository_factory.job.create(
             kind="generate_lecture_slide",
             payload=next_slide_payload,
             priority=int(
                 next_slide_payload.get("slide_priority", payload.get("slide_priority", -10))
             ),
+            parent_job_id=chain_parent_job_id,
         )
         return row.id
 
@@ -146,13 +159,17 @@ class JobService:
             "quickstart_start": self._handle_quickstart_start,
         }.get(kind)
 
-    async def _handle_generate_course(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+    async def _handle_generate_course(
+        self, payload: Dict[str, Any], parent_job_id: Optional[int] = None
+    ) -> Dict[str, Any]:
         service = self._course_generator_service_instance()
         partial = payload.get("partial_attributes") or {}
         result = await service.generate_course(partial)
         return {"generated_course": result}
 
-    async def _handle_create_course(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+    async def _handle_create_course(
+        self, payload: Dict[str, Any], parent_job_id: Optional[int] = None
+    ) -> Dict[str, Any]:
         """Create a course using smart department/professor selection/generation.
 
         Expects payload with fields matching CourseService.create_course signature.
@@ -186,24 +203,32 @@ class JobService:
             description=description,
             created_by=created_by,
             created_with=created_with,
+            parent_job_id=parent_job_id,
         )
 
         # After successful course creation, enqueue topic generation
+        topics_job_id = None
         try:
             job_enqueue_service = self._job_enqueue_service_instance()
-            job_enqueue_service.enqueue_topics_generation(course.id, created_by=created_by)
+            topics_job_id = job_enqueue_service.enqueue_topics_generation(
+                course.id, created_by=created_by, parent_job_id=parent_job_id
+            )
             self.logger.info(f"Enqueued topic generation for course {course.id}")
         except Exception as e:
             self.logger.warning(f"Failed to enqueue topic generation for course {course.id}: {e}")
-            # Don't fail the course creation if topic generation enqueue fails
 
-        return {
+        result: Dict[str, Any] = {
             "course_id": course.id,
             "department_id": course.department_id,
             "professor_id": professor.id,
         }
+        if topics_job_id is not None:
+            result["topics_job_id"] = topics_job_id
+        return result
 
-    async def _handle_generate_department(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+    async def _handle_generate_department(
+        self, payload: Dict[str, Any], parent_job_id: Optional[int] = None
+    ) -> Dict[str, Any]:
         service = self._department_generator_service_instance()
         partial = payload.get("partial_attributes") or {}
         freeform = payload.get("freeform_prompt")
@@ -213,18 +238,21 @@ class JobService:
         )
         return {"generated_department": result}
 
-    async def _handle_generate_professor(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+    async def _handle_generate_professor(
+        self, payload: Dict[str, Any], parent_job_id: Optional[int] = None
+    ) -> Dict[str, Any]:
         service = self._professor_generator_service_instance()
         partial = dict(payload.get("partial_attributes") or {})
         freeform_prompt = payload.get("freeform_prompt")
         if freeform_prompt:
-            # Align with synchronous API behavior by threading the prompt through the generator
             partial["freeform_prompt"] = freeform_prompt
 
         result = await service.generate_professor(partial)
         return {"generated_professor": result}
 
-    async def _handle_generate_topics_for_course(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+    async def _handle_generate_topics_for_course(
+        self, payload: Dict[str, Any], parent_job_id: Optional[int] = None
+    ) -> Dict[str, Any]:
         service = self._topic_generator_service_instance()
         course_id = payload.get("course_id")
         freeform = payload.get("freeform_prompt")
@@ -232,7 +260,6 @@ class JobService:
         if course_id is None:
             raise ValueError("course_id is required")
         topics = await service.generate_topics_for_course(course_id, freeform, created_by)
-        # Convert Topic models to minimal dicts
         return {
             "created_topics": [
                 {
@@ -246,7 +273,9 @@ class JobService:
             ]
         }
 
-    async def _handle_generate_lecture(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+    async def _handle_generate_lecture(
+        self, payload: Dict[str, Any], parent_job_id: Optional[int] = None
+    ) -> Dict[str, Any]:
         service = self._lecture_generator_service_instance()
         partial = payload.get("partial_attributes") or {}
         self.logger.info(f"Generating and saving lecture with partial attributes: {partial}")
@@ -272,6 +301,7 @@ class JobService:
                     kind="generate_lecture_summary",
                     payload=summary_payload,
                     priority=payload.get("priority", 0),
+                    parent_job_id=parent_job_id,
                 )
             except Exception as e:  # noqa: BLE001
                 self.logger.error(
@@ -288,9 +318,9 @@ class JobService:
                     kind="generate_lecture_audio",
                     payload={"lecture_id": saved_lecture.id, "topic_id": saved_lecture.topic_id},
                     priority=payload.get("priority", 0),
+                    parent_job_id=parent_job_id,
                 )
             except Exception as e:  # noqa: BLE001
-                # Don't fail the batch chain if audio enqueue fails.
                 self.logger.warning(
                     "Failed to enqueue audio generation for lecture %s: %s",
                     saved_lecture.id,
@@ -299,7 +329,9 @@ class JobService:
                 )
         else:
             # Use the complete workflow for non-batch jobs.
-            saved_lecture = await service.generate_and_save_lecture(partial)
+            saved_lecture = await service.generate_and_save_lecture(
+                partial, parent_job_id=parent_job_id
+            )
 
         self.logger.info(f"Generate and save lecture completed: {saved_lecture.id}")
         return {
@@ -310,7 +342,9 @@ class JobService:
             "transcript_url": saved_lecture.transcript_url,
         }
 
-    async def _handle_generate_lecture_text_only(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+    async def _handle_generate_lecture_text_only(
+        self, payload: Dict[str, Any], parent_job_id: Optional[int] = None
+    ) -> Dict[str, Any]:
         service = self._lecture_generator_service_instance()
         partial = payload.get("partial_attributes") or {}
         self.logger.info(
@@ -329,7 +363,9 @@ class JobService:
             "transcript_url": saved_lecture.transcript_url,
         }
 
-    async def _handle_generate_lecture_summary(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+    async def _handle_generate_lecture_summary(
+        self, payload: Dict[str, Any], parent_job_id: Optional[int] = None
+    ) -> Dict[str, Any]:
         service = self._lecture_generator_service_instance()
         lecture_id = payload.get("lecture_id")
         if lecture_id is None:
@@ -337,15 +373,19 @@ class JobService:
         result = await service.generate_lecture_summary(lecture_id)
         return result
 
-    async def _handle_generate_lecture_audio(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+    async def _handle_generate_lecture_audio(
+        self, payload: Dict[str, Any], parent_job_id: Optional[int] = None
+    ) -> Dict[str, Any]:
         service = self._lecture_generator_service_instance()
         lecture_id = payload.get("lecture_id")
         if lecture_id is None:
             raise ValueError("lecture_id is required")
-        result = await service.generate_lecture_audio(lecture_id)
+        result = await service.generate_lecture_audio(lecture_id, parent_job_id=parent_job_id)
         return result
 
-    async def _handle_generate_lecture_timeline(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+    async def _handle_generate_lecture_timeline(
+        self, payload: Dict[str, Any], parent_job_id: Optional[int] = None
+    ) -> Dict[str, Any]:
         service = self._lecture_generator_service_instance()
         lecture_id = payload.get("lecture_id")
         if lecture_id is None:
@@ -362,12 +402,13 @@ class JobService:
                     "topic_id": payload.get("topic_id") or getattr(lecture, "topic_id", None),
                 },
                 priority=int(payload.get("priority", 0)),
+                parent_job_id=parent_job_id,
             )
             result["remap_images_timeline_job_id"] = row.id
         return result
 
     async def _handle_remap_lecture_images_timeline(
-        self, payload: Dict[str, Any]
+        self, payload: Dict[str, Any], parent_job_id: Optional[int] = None
     ) -> Dict[str, Any]:
         service = self._lecture_images_generator_service_instance()
         lecture_id = payload.get("lecture_id")
@@ -381,7 +422,9 @@ class JobService:
         )
         return result
 
-    async def _handle_generate_lecture_images(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+    async def _handle_generate_lecture_images(
+        self, payload: Dict[str, Any], parent_job_id: Optional[int] = None
+    ) -> Dict[str, Any]:
         service = self._lecture_images_generator_service_instance()
         lecture_id = payload.get("lecture_id")
         if lecture_id is None:
@@ -403,7 +446,9 @@ class JobService:
         slide_payloads = result.pop("slide_payloads", [])
         slide_priority = int(payload.get("slide_priority", -10))
         first_slide_payload = self._build_lecture_slide_chain(
-            slide_payloads, slide_priority=slide_priority
+            slide_payloads,
+            slide_priority=slide_priority,
+            chain_parent_job_id=parent_job_id,
         )
         job_ids = []
         if first_slide_payload:
@@ -411,6 +456,7 @@ class JobService:
                 kind="generate_lecture_slide",
                 payload=first_slide_payload,
                 priority=slide_priority,
+                parent_job_id=parent_job_id,
             )
             job_ids.append(row.id)
 
@@ -419,7 +465,9 @@ class JobService:
         result["slide_job_ids"] = job_ids
         return result
 
-    async def _handle_resume_lecture_images(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+    async def _handle_resume_lecture_images(
+        self, payload: Dict[str, Any], parent_job_id: Optional[int] = None
+    ) -> Dict[str, Any]:
         service = self._lecture_images_generator_service_instance()
         lecture_id = payload.get("lecture_id")
         if lecture_id is None:
@@ -433,7 +481,9 @@ class JobService:
         slide_payloads = result.pop("slide_payloads", [])
         slide_priority = int(payload.get("slide_priority", -10))
         first_slide_payload = self._build_lecture_slide_chain(
-            slide_payloads, slide_priority=slide_priority
+            slide_payloads,
+            slide_priority=slide_priority,
+            chain_parent_job_id=parent_job_id,
         )
         job_ids = []
         if first_slide_payload:
@@ -441,6 +491,7 @@ class JobService:
                 kind="generate_lecture_slide",
                 payload=first_slide_payload,
                 priority=slide_priority,
+                parent_job_id=parent_job_id,
             )
             job_ids.append(row.id)
 
@@ -449,7 +500,9 @@ class JobService:
         result["slide_job_ids"] = job_ids
         return result
 
-    async def _handle_generate_lecture_slide(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+    async def _handle_generate_lecture_slide(
+        self, payload: Dict[str, Any], parent_job_id: Optional[int] = None
+    ) -> Dict[str, Any]:
         service = self._lecture_images_generator_service_instance()
         lecture_id = payload.get("lecture_id")
         slot_idx = payload.get("slot_idx")
@@ -476,7 +529,9 @@ class JobService:
             result["next_slide_job_id"] = next_job_id
         return result
 
-    async def _handle_generate_professor_image(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+    async def _handle_generate_professor_image(
+        self, payload: Dict[str, Any], parent_job_id: Optional[int] = None
+    ) -> Dict[str, Any]:
         service = self._professor_generator_service_instance()
         professor_id = payload.get("professor_id")
         aspect_ratio = payload.get("aspect_ratio", "1:1")
@@ -487,7 +542,9 @@ class JobService:
         )
         return {"professor_id": updated.id, "image_url": getattr(updated, "image_url", None)}
 
-    async def _handle_generate_course_image(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+    async def _handle_generate_course_image(
+        self, payload: Dict[str, Any], parent_job_id: Optional[int] = None
+    ) -> Dict[str, Any]:
         service = self._course_generator_service_instance()
         course_id = payload.get("course_id")
         aspect_ratio = payload.get("aspect_ratio", "1:1")
@@ -498,7 +555,9 @@ class JobService:
         )
         return {"course_id": updated.id, "image_url": getattr(updated, "image_url", None)}
 
-    async def _handle_export_course(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+    async def _handle_export_course(
+        self, payload: Dict[str, Any], parent_job_id: Optional[int] = None
+    ) -> Dict[str, Any]:
         """Export a course with all related data and assets."""
         service = self._course_export_service_instance()
         course_id = payload.get("course_id")
@@ -507,7 +566,9 @@ class JobService:
         result = await service.export_course(course_id)
         return result
 
-    async def _handle_quickstart_start(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+    async def _handle_quickstart_start(
+        self, payload: Dict[str, Any], parent_job_id: Optional[int] = None
+    ) -> Dict[str, Any]:
         """Start the quickstart course creation flow.
 
         Generates course data from user query and creates the course with smart
@@ -543,13 +604,14 @@ class JobService:
             title=generated_data.get("title") or "Quickstart Course",
             code=generated_data.get("code") or "QS001",
             level=generated_data.get("level") or "Undergraduate",
-            weeks=12,  # Quickstart courses use consistent 12 weeks
+            weeks=12,
             lectures_per_week=1,
-            department_id=None,  # Smart selection will handle this
-            professor_id=None,  # Smart selection will handle this
+            department_id=None,
+            professor_id=None,
             description=generated_data.get("description") or query,
             created_by=created_by,
             created_with=generated_data.get("created_with"),
+            parent_job_id=parent_job_id,
         )
 
         # Step 3: Set course to hidden status (will be published after user approval)

--- a/artificial_u/services/lecture_generator_service.py
+++ b/artificial_u/services/lecture_generator_service.py
@@ -195,6 +195,7 @@ class LectureGeneratorService:
     async def generate_and_save_lecture(
         self,
         partial_attributes: Optional[Dict[str, Any]] = None,
+        parent_job_id: Optional[int] = None,
     ) -> Lecture:
         """
         Generate lecture content using AI and save it as a complete lecture record.
@@ -223,7 +224,7 @@ class LectureGeneratorService:
         saved_lecture = await self._upload_and_update_transcript(saved_lecture, generated_dict)
 
         # Enqueue background processing jobs
-        self._enqueue_background_jobs_for_lecture(saved_lecture)
+        self._enqueue_background_jobs_for_lecture(saved_lecture, parent_job_id=parent_job_id)
 
         self.logger.info(
             f"Successfully generated and saved lecture {saved_lecture.id} "
@@ -333,7 +334,9 @@ class LectureGeneratorService:
             )
         return saved_lecture
 
-    def _enqueue_background_jobs_for_lecture(self, saved_lecture: Lecture) -> None:
+    def _enqueue_background_jobs_for_lecture(
+        self, saved_lecture: Lecture, parent_job_id: Optional[int] = None
+    ) -> None:
         """Enqueue background processing jobs for a lecture."""
         if get_settings().testing:
             return
@@ -348,7 +351,7 @@ class LectureGeneratorService:
         # Enqueue summary generation job
         try:
             self.job_enqueue_service.enqueue_lecture_summary_generation(
-                saved_lecture.id, topic_id=saved_lecture.topic_id
+                saved_lecture.id, topic_id=saved_lecture.topic_id, parent_job_id=parent_job_id
             )
         except Exception as e:
             self.logger.error(
@@ -360,7 +363,7 @@ class LectureGeneratorService:
         # Enqueue audio generation job (can run in parallel to summary)
         try:
             self.job_enqueue_service.enqueue_lecture_audio_generation(
-                saved_lecture.id, topic_id=saved_lecture.topic_id
+                saved_lecture.id, topic_id=saved_lecture.topic_id, parent_job_id=parent_job_id
             )
         except Exception as e:
             self.logger.error(
@@ -424,7 +427,9 @@ class LectureGeneratorService:
 
         return {"lecture_id": updated.id, "topic_id": updated.topic_id, "summary": updated.summary}
 
-    async def generate_lecture_audio(self, lecture_id: int) -> Dict[str, Any]:
+    async def generate_lecture_audio(
+        self, lecture_id: int, parent_job_id: Optional[int] = None
+    ) -> Dict[str, Any]:
         """Generate and store audio for the given lecture, updating audio_url and voice_id."""
         # 1. Fetch required entities
         lecture, course, topic, professor = self._fetch_entities_for_audio(lecture_id)
@@ -474,7 +479,7 @@ class LectureGeneratorService:
         # summary/audio are enqueued after content generation.
         try:
             self.job_enqueue_service.enqueue_lecture_timeline_generation(
-                updated.id, topic_id=updated.topic_id
+                updated.id, topic_id=updated.topic_id, parent_job_id=parent_job_id
             )
         except Exception as e:
             self.logger.error(

--- a/docs/BACKGROUND_JOBS_EVOLUTION_PLAN.md
+++ b/docs/BACKGROUND_JOBS_EVOLUTION_PLAN.md
@@ -264,25 +264,66 @@ delivery gap properly:
   - Worker: `cpu=512, memory=2048` with `--workers 1`, runs the async worker loop + thread pool.
 - Concrete numbers come from Category 1 data, not guesses.
 
-### 3.5 Progressive SSE/polling migration on the frontend
+### 3.5 Progressive SSE/polling migration on the frontend — MOSTLY DONE
 
-- Finish the client-side migration from SSE to polling for all non-admin flows.
-- Remove `job-events-hub.ts` from single-page flows; keep for the admin dashboard.
-- Document in `web/STYLE_GUIDE.md` (or a job-handling guide) which pattern to pick for new features.
-- Current polling migration intentionally tracks only known jobs initiated by the current browser tab/session. This avoids always-on page polling, but it means SPA navigation can lose awareness of downstream jobs unless the primary job result exposes them.
-- Medium-term improvement: add a tab-session job handoff registry in `web/src/utils/job-management.ts` for jobs started in this tab. It should survive SPA navigation, expire on TTL or terminal state, and disappear on hard refresh/new tab.
-- Avoid reintroducing broad eager polling as a substitute for missing backend contracts. If a page needs continuity after navigation, prefer tracking exact job IDs from the initiating flow; use short-lived, scoped `listJobs()` fallback only when exact IDs are unavailable.
+- SSE removed from all single-job flows. `job-events-hub.ts` is gone; SSE kept only for the admin jobs dashboard (`/api/v1/jobs/stream`).
+- `createJobTracker` (explicit local tracking) and `createJobPolling` (single known-job reactive primitive) cover all non-admin flows. `waitForJobResult` for promise-style generation flows.
+- §3.6 child-chaining closes the most critical "job spawns children" gaps (lecture generation, image generation) without broad polling.
 
-### 3.6 Standardize follow-up chaining
+**Remaining gap — SPA navigation handoff:**
+The tracker lives inside the component that initiated the job. When the user navigates away (e.g., Courses → CourseDetail after triggering course creation), the tracker is torn down and children of the original job (course image, topics) are never tracked. On CourseDetail, the tracker starts fresh with no knowledge of the in-flight parent.
 
-- The follow-up chain in `artificial_u/api/worker.py:_handle_follow_up` is powerful but bespoke. Consider replacing with a small "workflow" abstraction:
-  - Each workflow row has an ordered list of steps; worker enqueues the next step on completion.
-  - Or adopt an existing library (`arq` groups, `taskiq` workflows) if we decide to switch queues.
-- Only worth doing if follow-up semantics start accreting more branching logic.
-- Course creation currently demonstrates the contract gap: `create_course` returns `course_id`, but related image/topic jobs may be enqueued by different backend layers (`CourseService._save_course`, `JobService._handle_create_course`, or enqueue helpers) without returning child job IDs to the client.
-- Standardize follow-up enqueueing so any handler that creates downstream jobs can return a predictable `child_jobs`/`follow_up_jobs` structure in the parent job result, e.g. `{ id, kind, entity_type, entity_id }`.
-- Keep client handoff semantics bounded: the frontend should not need to infer all possible downstream jobs for an entity. The backend should either return child IDs explicitly or expose a workflow/run identifier that the client can poll.
-- Decide whether related jobs should be represented as parent/child rows, a workflow/run table, or structured job result metadata before adding more chained flows.
+Options (deferred):
+- **Session registry**: a module-level `Map<jobId, TrackerState>` in `job-management.ts` that survives SPA navigation, expires on TTL or terminal state, is cleared on hard refresh. New page instances check the registry on mount and adopt any in-flight jobs.
+- **Scoped fallback polling**: on page load, call `GET /jobs?parent_id={just-created-course-id}&status=queued,running` with a short TTL. Only fires if the session registry has no record. Avoids always-on polling while recovering from the navigation gap.
+- Avoid reintroducing broad eager polling as a substitute for exact job IDs.
+
+### 3.6 Standardize follow-up chaining — DONE (2026-04-29)
+
+**Approach chosen:** `parent_job_id` column on the jobs table (nullable FK, self-referential). Preferred over threading child IDs through return values because it decouples the tracking concern from service return signatures and makes the tree queryable at any time.
+
+**Backend (2026-04-29):**
+
+- **Migration** (`alembic/versions/d7e8f9a0b1c2`): added `parent_job_id INTEGER REFERENCES jobs(id)` + `idx_jobs_parent_job_id`.
+- **`JobModel`** (`artificial_u/models/database.py`): added `parent_job_id` column.
+- **`JobRepository.create()`** (`artificial_u/models/repositories/job.py`): added `parent_job_id` param; `list()` now filters by `parent_id`.
+- **`JobEnqueueService`** (`artificial_u/services/job_enqueue_service.py`): all `enqueue_*` methods now return `int` (job ID, or `None` in test mode) and accept `parent_job_id` keyword arg.
+- **`CourseService.create_course()` / `_save_course()`** (`artificial_u/services/course_service.py`): threads `parent_job_id` through so the course image job gets parented correctly even though it's enqueued inside the domain service.
+- **`LectureGeneratorService`** (`artificial_u/services/lecture_generator_service.py`): `generate_and_save_lecture` and `generate_lecture_audio` both accept `parent_job_id` and pass it through to `_enqueue_background_jobs_for_lecture` → summary/audio/timeline enqueue calls. Without this, `generate_lecture` children were unparented and invisible to the frontend.
+- **`JobService.dispatch()`** (`artificial_u/services/job_service.py`): added `parent_job_id` param, passes it to every handler. All handlers updated with `parent_job_id=None` kwarg; handlers that enqueue children pass it through. `_handle_create_course` now returns `topics_job_id` in its result. Slide chain: `_build_lecture_slide_chain` embeds `chain_parent_job_id` in each payload; `_enqueue_next_lecture_slide` reads it and sets `parent_job_id` on next-slide rows, so all slides point to the `generate_lecture_images` job.
+- **Worker** (`artificial_u/api/worker.py`): `_execute_job` passes `parent_job_id=job_id` to `dispatch()`, so every job's children are automatically linked.
+- **Jobs router** (`artificial_u/api/routers/jobs.py`): `parent_job_id` exposed in all job response shapes; `GET /jobs?parent_id={id}` supported; new `GET /jobs/{id}/children` endpoint returns direct children.
+
+**Frontend (2026-04-29):**
+
+- **`jobs-service.ts`**: `JobRow` gains `parent_job_id?: number | null`; `listJobChildren(parentJobId)` function added; `listJobs` accepts `parent_id` param.
+- **`job-management.ts`** — `createJobTracker` gains `trackChildren?: boolean` option. When a tracked job completes, `trackJobChildren` fires (fire-and-forget):
+  1. Fetches `/jobs/{id}/children` — auto-tracks any non-terminal direct children.
+  2. If the completing job has a `parent_job_id`, also fetches `/jobs/{parent}/children` to find non-terminal *siblings* — this is what drives the slide chain, where each slide enqueues the next as a sibling (same parent), not a child.
+- **Entity-navigation guard**: the `createEffect` that calls `stop()` on entity ID changes was previously firing when `lectureId` transitioned from `undefined` to a real ID (new lecture just created) or when the `lecture()` prop briefly refreshed after a job completed. Fixed to only stop when an existing defined ID changes to a *different* defined ID — i.e., genuine SPA navigation, not data arrival.
+- **`TopicDetail.tsx`**: added `generate_lecture_timeline` to the `kinds` list (it was filtered out, breaking the audio → timeline chain); added `generate_lecture_timeline` to `onJobComplete` so `refetchLecture()` fires when the timeline finishes (gates the "Generate Lecture Images" button).
+- **`trackChildren: true`** wired into `TopicDetail`, `LectureDetail`, and `LectureSection` trackers.
+
+**Verified job trees (live testing):**
+```
+generate_lecture (id=N)                      ← tracked by TopicDetail
+  ├── generate_lecture_summary (parent=N)    ← auto-tracked as child
+  └── generate_lecture_audio   (parent=N)    ← auto-tracked as child
+        └── generate_lecture_timeline        ← auto-tracked as child of audio
+
+generate_lecture_images (id=M)              ← tracked by LectureSection
+  ├── generate_lecture_slide slot 0 (parent=M)   ← auto-tracked as child
+  ├── generate_lecture_slide slot 1 (parent=M)   ← auto-tracked as sibling
+  ├── ...
+  └── generate_lecture_slide slot N-1 (parent=M) ← auto-tracked as sibling
+```
+Frontend follows the full tree to completion; UI updates (audio player, timeline gate, image gallery) appear without manual refresh.
+
+**Still to do / open decisions:**
+- Remove the `[job-chain]` debug `console.log` statements from `job-management.ts` once behavior is confirmed stable in production.
+- Wire `trackChildren: true` into the course creation page / quickstart flow (SPA navigation gap means the tracker is often gone by the time children are enqueued — see §3.5).
+- `generate_topics_for_course` enqueues individual lecture jobs inside `topic_generator_service`; those could be parented to the topics job if the service accepts `parent_job_id`. Deferred — requires threading into the generator service layer.
+- Workflow library abstraction (`arq` groups etc.) — still not worth it until branching logic accretes.
 
 ---
 

--- a/docs/BACKGROUND_JOBS_EVOLUTION_PLAN.md
+++ b/docs/BACKGROUND_JOBS_EVOLUTION_PLAN.md
@@ -264,19 +264,120 @@ delivery gap properly:
   - Worker: `cpu=512, memory=2048` with `--workers 1`, runs the async worker loop + thread pool.
 - Concrete numbers come from Category 1 data, not guesses.
 
-### 3.5 Progressive SSE/polling migration on the frontend — MOSTLY DONE
+### 3.5 Progressive SSE/polling migration on the frontend — COURSE HANDOFF DONE
 
 - SSE removed from all single-job flows. `job-events-hub.ts` is gone; SSE kept only for the admin jobs dashboard (`/api/v1/jobs/stream`).
 - `createJobTracker` (explicit local tracking) and `createJobPolling` (single known-job reactive primitive) cover all non-admin flows. `waitForJobResult` for promise-style generation flows.
 - §3.6 child-chaining closes the most critical "job spawns children" gaps (lecture generation, image generation) without broad polling.
+- New Course Creation now preserves same-tab SPA continuity from `Courses.tsx` to `CourseDetail.tsx`: the client registers a course-scoped handoff before navigation, the detail page adopts it, discovers active child jobs, and refreshes the course image/topics when jobs complete.
 
-**Remaining gap — SPA navigation handoff:**
-The tracker lives inside the component that initiated the job. When the user navigates away (e.g., Courses → CourseDetail after triggering course creation), the tracker is torn down and children of the original job (course image, topics) are never tracked. On CourseDetail, the tracker starts fresh with no knowledge of the in-flight parent.
+**Completed — limited SPA navigation handoff for New Course Creation:**
 
-Options (deferred):
-- **Session registry**: a module-level `Map<jobId, TrackerState>` in `job-management.ts` that survives SPA navigation, expires on TTL or terminal state, is cleared on hard refresh. New page instances check the registry on mount and adopt any in-flight jobs.
-- **Scoped fallback polling**: on page load, call `GET /jobs?parent_id={just-created-course-id}&status=queued,running` with a short TTL. Only fires if the session registry has no record. Avoids always-on polling while recovering from the navigation gap.
-- Avoid reintroducing broad eager polling as a substitute for exact job IDs.
+The polling primitives are intentionally page-local. That is fine while the user
+stays put, but it loses continuity when the initiating page navigates away. The
+important case is New Course Creation:
+
+1. `Courses.tsx` enqueues `create_course` and polls that known job.
+2. The backend creates the course, then enqueues follow-up jobs for the new
+   course (`generate_course_image`, `generate_topics_for_course`, and any topic
+   slot children).
+3. `Courses.tsx` receives the completed `create_course` job and navigates to
+   `/courses/{course_id}`.
+4. The `Courses.tsx` polling primitive is cleaned up on unmount, so
+   `CourseDetail.tsx` has no in-memory awareness of the parent or follow-up jobs.
+   Backend work succeeds, but the detail page does not refresh image/topics.
+
+Implemented with a session-scoped handoff registry + page adoption.
+
+Keep the scope deliberately narrow: continuity across same-tab SPA navigation,
+not hard refresh, cross-tab, or multi-device sync.
+
+- Added a module-level registry in `web/src/utils/job-management.ts`:
+  `Map<string, JobHandoff>`, cleared naturally on hard refresh and pruned on TTL
+  or terminal state. Use entity-scoped keys like `course:{courseId}` rather than
+  only `job:{jobId}` so the destination route can adopt without knowing every
+  child ID up front.
+- When `Courses.tsx` sees `create_course` complete, it parses:
+  - `course_id` from `job.result.course_id`
+  - `topics_job_id` from `job.result.topics_job_id` when present
+  - the parent `create_course` job ID from `job.id`
+- Before calling `navigate('/courses/{id}')`, it registers a handoff:
+  ```ts
+  registerJobHandoff({
+    entity: { type: 'course', id: courseId },
+    parentJobIds: [createCourseJobId],
+    jobIds: [topicsJobId].filter(Boolean),
+    kinds: [
+      'create_course',
+      'generate_course_image',
+      'generate_topics_for_course',
+      'generate_topic_for_course_slot',
+    ],
+    expiresAt: Date.now() + 10 * 60_000,
+  })
+  ```
+- On `CourseDetail.tsx` mount, the page calls an adoption helper for the current course:
+  `adoptJobHandoff({ entity: { type: 'course', id: courseId }, ...callbacks })`.
+  The helper:
+  - track known `jobIds`
+  - query `GET /jobs/{parent}/children` once for each known parent and track
+    active direct children
+  - with `trackChildren: true`, continue discovering any slot-child chain as
+    each parent/sibling completes
+  - prunes handoffs by TTL; follow-up work can remove handoffs eagerly once
+    there are no active jobs left
+- In `CourseDetail.tsx`, completion callbacks refresh only affected
+  resources:
+  - `generate_course_image` done → `refetchCourse()`
+  - `generate_topics_for_course` done → `refetchTopics()`
+  - `generate_topic_for_course_slot` done → `refetchTopics()` (or throttle/debounce
+    to avoid one request per slot if topics are generated in a fast burst)
+  - `create_course` done can be ignored on the detail page except for child
+    discovery, because the course page is already loaded.
+
+**Scoped fallback when registry has no record — implemented:**
+
+Use this only on the destination page and only for likely-stale placeholders
+(e.g., course has no image or topics are empty). It should run for a short window
+after mount, then stop.
+
+- Query active jobs for the course, not all user jobs:
+  - `GET /jobs?course_id={courseId}&status=queued`
+  - `GET /jobs?course_id={courseId}&status=running`
+- Filter to relevant kinds:
+  `generate_course_image`, `generate_topics_for_course`,
+  `generate_topic_for_course_slot`.
+- Track any returned IDs with the same `createJobTracker` path and
+  `trackChildren: true`.
+- This recovers from small race windows, direct deep links after course creation
+  in the same tab, or a missing `topics_job_id`, without broad eager polling.
+
+**Backend contract verified for course creation:**
+
+- `create_course` result includes `course_id` and includes
+  `topics_job_id` when topic generation is enqueued.
+- `generate_course_image`, `generate_topics_for_course`, and
+  `generate_topic_for_course_slot` payloads include `course_id`, so
+  `GET /jobs?course_id={id}` can recover active work.
+- Child topic-slot jobs are discoverable through the active course/job filters
+  used by the handoff adoption path.
+
+**Non-goals for this phase:**
+
+- No always-on polling in `CourseDetail.tsx`.
+- No cross-tab or hard-refresh recovery beyond the scoped fallback above.
+- No return to SSE for course detail pages.
+
+**Still to do: identify other SPA handoff cases.**
+
+- Audit the web client for other flows where a component starts a known job and
+  then navigates before downstream jobs complete.
+- For each confirmed case, either wire it into `registerJobHandoff` /
+  `adoptJobHandoff` with an entity-scoped key or explicitly document why local
+  tracking is sufficient.
+- Likely candidates to review: quickstart finalization → course detail,
+  topic-to-lecture creation flows, and any admin/detail transitions that enqueue
+  jobs before route changes.
 
 ### 3.6 Standardize follow-up chaining — DONE (2026-04-29)
 

--- a/tests/unit/services/test_job_service.py
+++ b/tests/unit/services/test_job_service.py
@@ -10,7 +10,16 @@ class FakeJobRepository:
     def __init__(self):
         self.created = []
 
-    def create(self, *, kind, payload, priority=0, run_after=None, max_attempts=2):
+    def create(
+        self,
+        *,
+        kind,
+        payload,
+        priority=0,
+        run_after=None,
+        max_attempts=2,
+        parent_job_id=None,
+    ):
         row = SimpleNamespace(id=len(self.created) + 1)
         self.created.append(
             {
@@ -19,6 +28,7 @@ class FakeJobRepository:
                 "priority": priority,
                 "run_after": run_after,
                 "max_attempts": max_attempts,
+                "parent_job_id": parent_job_id,
             }
         )
         return row

--- a/web/src/api/services/jobs-service.ts
+++ b/web/src/api/services/jobs-service.ts
@@ -16,6 +16,7 @@ export interface JobRow {
   /** Wall-clock execution time of the last attempt, when available (from worker telemetry). */
   duration_ms?: number | null
   payload?: unknown
+  parent_job_id?: number | null
   created_at?: string
   updated_at?: string
 }
@@ -31,6 +32,7 @@ export async function listJobs(params?: {
   lecture_id?: number
   topic_id?: number
   course_id?: number
+  parent_id?: number
 }): Promise<JobRow[]> {
   const qs = new URLSearchParams()
   if (params?.status) qs.set('status', params.status)
@@ -39,8 +41,13 @@ export async function listJobs(params?: {
   if (params?.lecture_id != null) qs.set('lecture_id', String(params.lecture_id))
   if (params?.topic_id != null) qs.set('topic_id', String(params.topic_id))
   if (params?.course_id != null) qs.set('course_id', String(params.course_id))
+  if (params?.parent_id != null) qs.set('parent_id', String(params.parent_id))
   const endpoint = `${ENDPOINTS.jobs.list}${qs.toString() ? `?${qs.toString()}` : ''}`
   return httpClient.get<JobRow[]>(endpoint)
+}
+
+export async function listJobChildren(parentJobId: number): Promise<JobRow[]> {
+  return httpClient.get<JobRow[]>(`${ENDPOINTS.jobs.detail(parentJobId)}/children`)
 }
 
 export async function cancelJob(jobId: number): Promise<{ id: number; status: string }> {

--- a/web/src/components/lectures/LectureSection.tsx
+++ b/web/src/components/lectures/LectureSection.tsx
@@ -53,7 +53,8 @@ export const LectureSection: Component<LectureSectionProps> = (props) => {
   // Track jobs started from this lecture section instance.
   const jobTracker = createJobTracker({
     topicId: () => props.topicId,
-    lectureId: () => props.lecture()?.id, // This will reactively update when lecture is created
+    lectureId: () => props.lecture()?.id,
+    trackChildren: true,
     kinds: [
       'generate_lecture',
       'generate_lecture_text_only',

--- a/web/src/pages/CourseDetail.tsx
+++ b/web/src/pages/CourseDetail.tsx
@@ -18,6 +18,23 @@ import type { CourseFormData } from '../components/courses/types.jsx'
 import { Alert, Button, MagicButton, MetadataInfo, ShareButton } from '../components/ui'
 import { useTranslations } from '../i18n'
 import { useAudioPlayer } from '../utils/audio-player-context.jsx'
+import { adoptJobHandoff } from '../utils/job-management.js'
+
+const COURSE_CREATION_HANDOFF_KINDS = [
+  'create_course',
+  'generate_course_image',
+  'generate_topics_for_course',
+  'generate_topic_for_course_slot',
+]
+
+const TOPIC_GENERATION_JOB_KINDS = new Set([
+  'generate_topics_for_course',
+  'generate_topic_for_course_slot',
+])
+
+function isTopicGenerationJob(kind: string): boolean {
+  return TOPIC_GENERATION_JOB_KINDS.has(kind)
+}
 
 // Department Info Component
 const DepartmentInfo: Component<{
@@ -305,7 +322,7 @@ const CourseDetail: Component = () => {
   // Check if courseId is a valid number before creating resources
   const isValidId = !Number.isNaN(courseId)
 
-  const [courseData, { refetch }] = createResource(
+  const [courseData, { refetch: refetchCourse }] = createResource(
     () => (isValidId ? courseId : null), // Pass null if ID is invalid
     courseService.getCourse
   )
@@ -321,10 +338,73 @@ const CourseDetail: Component = () => {
     () => (isValidId ? courseId : null),
     courseService.getCourseLectures
   )
-  const [topicsData] = createResource(
+  const [topicsData, { refetch: refetchTopics }] = createResource(
     () => (isValidId ? courseId : null),
     (id) => topicService.listTopicsByCourse(id, 1, 100)
   )
+
+  const [activeImageJobIds, setActiveImageJobIds] = createSignal<Set<number>>(new Set())
+  const [activeTopicJobIds, setActiveTopicJobIds] = createSignal<Set<number>>(new Set())
+
+  const markActiveJob = (setter: typeof setActiveImageJobIds, jobId: number) => {
+    setter((prev) => {
+      if (prev.has(jobId)) return prev
+      const next = new Set(prev)
+      next.add(jobId)
+      return next
+    })
+  }
+
+  const clearActiveJob = (setter: typeof setActiveImageJobIds, jobId: number) => {
+    setter((prev) => {
+      if (!prev.has(jobId)) return prev
+      const next = new Set(prev)
+      next.delete(jobId)
+      return next
+    })
+  }
+
+  const hasActiveImageJobs = () => activeImageJobIds().size > 0
+  const hasActiveTopicJobs = () => activeTopicJobIds().size > 0
+
+  adoptJobHandoff({
+    entity: () => (isValidId ? { type: 'course', id: courseId } : null),
+    kinds: COURSE_CREATION_HANDOFF_KINDS,
+    fallback: () => {
+      const course = courseData()
+      const topics = topicsData()
+      if (!isValidId || courseData.loading || topicsData.loading || !course || !topics) {
+        return false
+      }
+      return !course.image_url || topics.items.length === 0
+    },
+    onJobStart: (event) => {
+      if (event.kind === 'generate_course_image') {
+        markActiveJob(setActiveImageJobIds, event.id)
+      }
+      if (isTopicGenerationJob(event.kind)) {
+        markActiveJob(setActiveTopicJobIds, event.id)
+      }
+    },
+    onJobComplete: (event) => {
+      if (event.kind === 'generate_course_image') {
+        clearActiveJob(setActiveImageJobIds, event.id)
+        void refetchCourse()
+      }
+      if (isTopicGenerationJob(event.kind)) {
+        clearActiveJob(setActiveTopicJobIds, event.id)
+        void refetchTopics()
+      }
+    },
+    onJobFail: (event) => {
+      if (event.kind === 'generate_course_image') {
+        clearActiveJob(setActiveImageJobIds, event.id)
+      }
+      if (isTopicGenerationJob(event.kind)) {
+        clearActiveJob(setActiveTopicJobIds, event.id)
+      }
+    },
+  })
 
   // Handler for course update form submission
   const handleUpdateCourse = async (formData: CourseFormData) => {
@@ -349,7 +429,7 @@ const CourseDetail: Component = () => {
     try {
       await courseService.updateCourse(courseId, updatePayload)
       setIsEditing(false)
-      void refetch()
+      void refetchCourse()
     } catch (err) {
       setError(err instanceof Error ? err.message : t().courseDetail.failedToUpdate)
     } finally {
@@ -414,7 +494,7 @@ const CourseDetail: Component = () => {
     setError('')
     try {
       await courseService.generateCourseImage(courseId)
-      void refetch()
+      void refetchCourse()
     } catch (err: unknown) {
       setImageGenerationError(
         err instanceof Error ? err.message : 'Failed to generate course image'
@@ -433,7 +513,7 @@ const CourseDetail: Component = () => {
     void courseService
       .publishCourse(courseId)
       .then(() => {
-        void refetch()
+        void refetchCourse()
       })
       .catch((err: unknown) => {
         setError(err instanceof Error ? err.message : t().courseDetail.failedToPublish)
@@ -492,7 +572,7 @@ const CourseDetail: Component = () => {
                         <MagicButton
                           variant="ghost"
                           onClick={() => void handleGenerateCourseImage()}
-                          isLoading={isGeneratingImage()}
+                          isLoading={isGeneratingImage() || hasActiveImageJobs()}
                           loadingText={t().common.generating}
                         >
                           {course().image_url ? 'Regenerate Image' : 'Generate Image'}
@@ -700,7 +780,7 @@ const CourseDetail: Component = () => {
                       courseId={courseId}
                       courseCode={course().code}
                       loading={topicsData.loading}
-                      isGenerating={false}
+                      isGenerating={hasActiveTopicJobs()}
                     />
                   </div>
                 </Show>

--- a/web/src/pages/Courses.tsx
+++ b/web/src/pages/Courses.tsx
@@ -11,7 +11,7 @@ import { Alert, Button, MagicButton } from '../components/ui'
 import type { SelectOption } from '../components/ui/Select.jsx'
 import Select from '../components/ui/Select.jsx'
 import { useTranslations } from '../i18n'
-import { createJobPolling } from '../utils/job-management.js'
+import { createJobPolling, registerJobHandoff } from '../utils/job-management.js'
 
 type SortField =
   | 'code'
@@ -205,8 +205,24 @@ const Courses: Component = () => {
         job.result && typeof job.result === 'object' && 'course_id' in job.result
           ? Number((job.result as { course_id?: unknown }).course_id)
           : Number.NaN
+      const topicsJobId =
+        job.result && typeof job.result === 'object' && 'topics_job_id' in job.result
+          ? Number((job.result as { topics_job_id?: unknown }).topics_job_id)
+          : Number.NaN
 
-      if (!Number.isNaN(createdCourseId)) {
+      if (Number.isFinite(createdCourseId)) {
+        registerJobHandoff({
+          entity: { type: 'course', id: createdCourseId },
+          parentJobIds: [job.id],
+          jobIds: Number.isFinite(topicsJobId) ? [topicsJobId] : [],
+          kinds: [
+            'create_course',
+            'generate_course_image',
+            'generate_topics_for_course',
+            'generate_topic_for_course_slot',
+          ],
+          expiresAt: Date.now() + 10 * 60_000,
+        })
         navigate(`/courses/${String(createdCourseId)}`)
         return
       }

--- a/web/src/pages/LectureDetail.tsx
+++ b/web/src/pages/LectureDetail.tsx
@@ -427,6 +427,7 @@ const LectureDetail = () => {
 
   const jobTracker = createJobTracker({
     lectureId: () => (isValidIds() ? lectureId() : undefined),
+    trackChildren: true,
     kinds: [
       'generate_lecture',
       'generate_lecture_text_only',

--- a/web/src/pages/TopicDetail.tsx
+++ b/web/src/pages/TopicDetail.tsx
@@ -86,11 +86,13 @@ const TopicDetail = () => {
   const jobTracker = createJobTracker({
     topicId: () => (isValidIds() ? topicId() : undefined),
     lectureId: () => lectureId(),
+    trackChildren: true,
     kinds: [
       'generate_lecture',
       'generate_lecture_text_only',
       'generate_lecture_audio',
       'generate_lecture_summary',
+      'generate_lecture_timeline',
     ],
     onJobComplete: (event) => {
       if (import.meta.env.DEV) {
@@ -108,9 +110,10 @@ const TopicDetail = () => {
         }, 100)
       } else if (
         event.kind === 'generate_lecture_audio' ||
-        event.kind === 'generate_lecture_summary'
+        event.kind === 'generate_lecture_summary' ||
+        event.kind === 'generate_lecture_timeline'
       ) {
-        // Also refresh for audio/summary completion
+        // Refresh for audio/summary/timeline completion
         setTimeout(() => {
           void refetchLecture()
         }, 100)

--- a/web/src/utils/job-management.ts
+++ b/web/src/utils/job-management.ts
@@ -11,12 +11,14 @@ import {
   type JobRow,
   type JobStatus,
   listJobChildren,
+  listJobs,
 } from '../api/services/jobs-service.js'
 import { jobDebug } from './job-debug.js'
 
 const DEFAULT_JOB_POLL_INTERVAL_MS = 2000
 const TERMINAL_JOB_STATUSES = new Set<JobStatus>(['done', 'failed', 'cancelled'])
 const ACTIVE_JOB_STATUSES = new Set<JobStatus>(['queued', 'running'])
+const DEFAULT_JOB_HANDOFF_TTL_MS = 10 * 60_000
 
 export interface JobTrackerOptions {
   topicId?: () => number | undefined
@@ -29,6 +31,79 @@ export interface JobTrackerOptions {
   onJobComplete?: (event: JobEvent) => void
   onJobStart?: (event: JobEvent) => void
   onJobFail?: (event: JobEvent) => void
+}
+
+export interface JobHandoffEntity {
+  type: 'course'
+  id: number
+}
+
+export interface JobHandoff {
+  entity: JobHandoffEntity
+  parentJobIds?: number[]
+  jobIds?: number[]
+  kinds?: string[]
+  expiresAt?: number
+}
+
+export interface JobHandoffAdoptionOptions {
+  entity: MaybeAccessor<JobHandoffEntity | null | undefined>
+  kinds?: string[]
+  pollIntervalMs?: number
+  fallback?: MaybeAccessor<boolean>
+  onJobComplete?: (event: JobEvent) => void
+  onJobStart?: (event: JobEvent) => void
+  onJobFail?: (event: JobEvent) => void
+}
+
+const jobHandoffs = new Map<string, Required<JobHandoff>>()
+const fallbackAttemptKeys = new Set<string>()
+
+function uniqueNumbers(values: Array<number | null | undefined>): number[] {
+  return [...new Set(values.filter((value): value is number => typeof value === 'number'))]
+}
+
+function handoffKey(entity: JobHandoffEntity): string {
+  return `${entity.type}:${String(entity.id)}`
+}
+
+function normalizeJobHandoff(handoff: JobHandoff): Required<JobHandoff> {
+  return {
+    entity: handoff.entity,
+    parentJobIds: uniqueNumbers(handoff.parentJobIds ?? []),
+    jobIds: uniqueNumbers(handoff.jobIds ?? []),
+    kinds: [...new Set(handoff.kinds ?? [])],
+    expiresAt: handoff.expiresAt ?? Date.now() + DEFAULT_JOB_HANDOFF_TTL_MS,
+  }
+}
+
+function pruneJobHandoffs(now = Date.now()) {
+  for (const [key, handoff] of jobHandoffs.entries()) {
+    if (handoff.expiresAt <= now) {
+      jobHandoffs.delete(key)
+      fallbackAttemptKeys.delete(key)
+    }
+  }
+}
+
+export function registerJobHandoff(handoff: JobHandoff) {
+  pruneJobHandoffs()
+  const key = handoffKey(handoff.entity)
+  const existing = jobHandoffs.get(key)
+  const next = normalizeJobHandoff(handoff)
+
+  if (!existing) {
+    jobHandoffs.set(key, next)
+    return
+  }
+
+  jobHandoffs.set(key, {
+    entity: next.entity,
+    parentJobIds: uniqueNumbers([...existing.parentJobIds, ...next.parentJobIds]),
+    jobIds: uniqueNumbers([...existing.jobIds, ...next.jobIds]),
+    kinds: [...new Set([...existing.kinds, ...next.kinds])],
+    expiresAt: Math.max(existing.expiresAt, next.expiresAt),
+  })
 }
 
 function toJobEvent(job: JobRow): JobEvent {
@@ -317,6 +392,101 @@ export function createJobTracker(options: JobTrackerOptions) {
     lastError,
     clearError: () => setLastError(null),
   }
+}
+
+export function adoptJobHandoff(options: JobHandoffAdoptionOptions) {
+  const trackedJobIds = new Set<number>()
+
+  const entity = () => resolveMaybeAccessor(options.entity)
+  const fallbackEnabled = () =>
+    options.fallback === undefined ? false : resolveMaybeAccessor(options.fallback)
+
+  const tracker = createJobTracker({
+    courseId: () => {
+      const currentEntity = entity()
+      return currentEntity?.type === 'course' ? currentEntity.id : undefined
+    },
+    kinds: options.kinds,
+    pollIntervalMs: options.pollIntervalMs,
+    trackChildren: true,
+    onJobStart: options.onJobStart,
+    onJobComplete: options.onJobComplete,
+    onJobFail: options.onJobFail,
+  })
+
+  const trackOnce = (jobId: number | null | undefined) => {
+    if (jobId == null || trackedJobIds.has(jobId)) return
+    trackedJobIds.add(jobId)
+    tracker.track(jobId)
+  }
+
+  const discoverChildren = async (parentJobIds: number[]) => {
+    await Promise.all(
+      parentJobIds.map(async (parentJobId) => {
+        try {
+          const children = await listJobChildren(parentJobId)
+          for (const child of children) {
+            if (matchesJobKind(child, options.kinds)) {
+              trackOnce(child.id)
+            }
+          }
+        } catch (error) {
+          jobDebug.log('error', `Failed to adopt child jobs for ${String(parentJobId)}`, error)
+        }
+      })
+    )
+  }
+
+  const adoptRegisteredHandoff = async (currentEntity: JobHandoffEntity): Promise<boolean> => {
+    pruneJobHandoffs()
+    const key = handoffKey(currentEntity)
+    const handoff = jobHandoffs.get(key)
+    if (!handoff) return false
+
+    for (const jobId of handoff.parentJobIds) trackOnce(jobId)
+    for (const jobId of handoff.jobIds) trackOnce(jobId)
+    await discoverChildren(handoff.parentJobIds)
+    return true
+  }
+
+  const discoverActiveCourseJobs = async (currentEntity: JobHandoffEntity) => {
+    try {
+      const [queued, running] = await Promise.all([
+        listJobs({ course_id: currentEntity.id, status: 'queued', limit: 100 }),
+        listJobs({ course_id: currentEntity.id, status: 'running', limit: 100 }),
+      ])
+      const activeJobs = [...queued, ...running].filter((job) => matchesJobKind(job, options.kinds))
+      for (const job of activeJobs) trackOnce(job.id)
+      await discoverChildren(activeJobs.map((job) => job.id))
+    } catch (error) {
+      jobDebug.log(
+        'error',
+        `Failed to discover active jobs for course ${String(currentEntity.id)}`,
+        error
+      )
+    }
+  }
+
+  createEffect(
+    on(
+      () => [entity(), fallbackEnabled()] as const,
+      ([currentEntity, shouldFallback]) => {
+        if (!currentEntity) return
+        const key = handoffKey(currentEntity)
+
+        void (async () => {
+          const adopted = await adoptRegisteredHandoff(currentEntity)
+          if (adopted || !shouldFallback || fallbackAttemptKeys.has(key)) return
+
+          fallbackAttemptKeys.add(key)
+          await discoverActiveCourseJobs(currentEntity)
+        })()
+      },
+      { defer: false }
+    )
+  )
+
+  return tracker
 }
 
 /**

--- a/web/src/utils/job-management.ts
+++ b/web/src/utils/job-management.ts
@@ -5,7 +5,13 @@
 
 import { type Accessor, createEffect, createMemo, createSignal, on, onCleanup } from 'solid-js'
 import { TIMEOUT_CONFIG } from '../api/config.js'
-import { getJob, type JobEvent, type JobRow, type JobStatus } from '../api/services/jobs-service.js'
+import {
+  getJob,
+  type JobEvent,
+  type JobRow,
+  type JobStatus,
+  listJobChildren,
+} from '../api/services/jobs-service.js'
 import { jobDebug } from './job-debug.js'
 
 const DEFAULT_JOB_POLL_INTERVAL_MS = 2000
@@ -18,6 +24,8 @@ export interface JobTrackerOptions {
   courseId?: () => number | undefined
   kinds?: string[]
   pollIntervalMs?: number
+  /** When true, automatically track child jobs when a parent job completes. */
+  trackChildren?: boolean
   onJobComplete?: (event: JobEvent) => void
   onJobStart?: (event: JobEvent) => void
   onJobFail?: (event: JobEvent) => void
@@ -89,6 +97,9 @@ export function createJobTracker(options: JobTrackerOptions) {
 
   const stop = (jobId?: number) => {
     if (jobId === undefined) {
+      console.log(
+        `[job-chain] stop() ALL called, runId ${String(runId)} → ${String(runId + 1)}, activeIds=${JSON.stringify([...activeJobIds()])}`
+      )
       runId += 1
       clearAllPollTimers()
       setActiveJobIds(new Set<number>())
@@ -115,11 +126,74 @@ export function createJobTracker(options: JobTrackerOptions) {
     pollTimers.set(jobId, setTimeout(poll, options.pollIntervalMs ?? DEFAULT_JOB_POLL_INTERVAL_MS))
   }
 
+  const trackJobChildren = (job: JobRow) => {
+    void (async () => {
+      try {
+        console.log(
+          `[job-chain] trackJobChildren: job=${job.kind}#${String(job.id)} parent_job_id=${String(job.parent_job_id)} runId=${String(runId)}`
+        )
+
+        // Direct children of the completing job
+        const children = await listJobChildren(job.id)
+        console.log(
+          `[job-chain] children of #${String(job.id)}:`,
+          children.map((c) => `${c.kind}#${String(c.id)}(${c.status})`)
+        )
+        for (const child of children) {
+          if (!TERMINAL_JOB_STATUSES.has(child.status)) {
+            jobDebug.log(
+              'state_change',
+              `Auto-tracking child job ${child.kind} #${String(child.id)}`,
+              { parentId: job.id }
+            )
+            console.log(
+              `[job-chain] tracking child #${String(child.id)} (${child.kind}) runId=${String(runId)}`
+            )
+            track(child.id)
+          }
+        }
+
+        // Siblings: if this job has a parent, also check parent's children.
+        // Handles sequential chains (e.g. lecture slides) where each slide's
+        // successor is a sibling (same parent_job_id), not a child.
+        if (job.parent_job_id != null) {
+          const siblings = await listJobChildren(job.parent_job_id)
+          console.log(
+            `[job-chain] siblings of parent#${String(job.parent_job_id)}:`,
+            siblings.map((s) => `${s.kind}#${String(s.id)}(${s.status})`)
+          )
+          for (const sibling of siblings) {
+            if (!TERMINAL_JOB_STATUSES.has(sibling.status) && sibling.id !== job.id) {
+              jobDebug.log(
+                'state_change',
+                `Auto-tracking sibling job ${sibling.kind} #${String(sibling.id)}`,
+                { parentId: job.parent_job_id }
+              )
+              console.log(
+                `[job-chain] tracking sibling #${String(sibling.id)} (${sibling.kind}) runId=${String(runId)}`
+              )
+              track(sibling.id)
+            }
+          }
+        }
+      } catch (err) {
+        console.warn('[job-chain] trackJobChildren error:', err)
+        // Non-fatal: child tracking is best-effort
+      }
+    })()
+  }
+
   const handlePolledJob = (job: JobRow) => {
     if (!matchesJobKind(job, options.kinds)) {
+      console.log(
+        `[job-chain] handlePolledJob: #${String(job.id)} (${job.kind}) FILTERED OUT by kinds`
+      )
       removeActiveJob(job.id)
       return false
     }
+    console.log(
+      `[job-chain] handlePolledJob: #${String(job.id)} (${job.kind}) status=${job.status} activeIds=${JSON.stringify([...activeJobIds()])} runId=${String(runId)}`
+    )
 
     if (isActiveJobStatus(job.status)) {
       markActiveJob(job.id)
@@ -143,6 +217,9 @@ export function createJobTracker(options: JobTrackerOptions) {
 
     if (job.status === 'done') {
       jobDebug.log('state_change', `Job completed: ${job.kind} #${String(job.id)}`, job)
+      if (options.trackChildren) {
+        trackJobChildren(job)
+      }
       options.onJobComplete?.(toJobEvent(job))
     } else if (job.status === 'failed' || job.status === 'cancelled') {
       setLastError(`Job ${job.kind} failed`)
@@ -154,17 +231,33 @@ export function createJobTracker(options: JobTrackerOptions) {
 
   const track = (jobId: number) => {
     const currentRunId = runId
+    console.log(`[job-chain] track called: #${String(jobId)} currentRunId=${String(currentRunId)}`)
     markActiveJob(jobId)
     setLastError(null)
 
     const poll = () => {
       void (async () => {
-        if (currentRunId !== runId) return
+        if (currentRunId !== runId) {
+          console.log(
+            `[job-chain] poll aborted (stale runId): job#${String(jobId)} currentRunId=${String(currentRunId)} runId=${String(runId)}`
+          )
+          return
+        }
 
         try {
           const job = await getJob(jobId)
-          if (currentRunId !== runId) return
-          if (!activeJobIds().has(jobId)) return
+          if (currentRunId !== runId) {
+            console.log(
+              `[job-chain] poll result discarded (stale runId after fetch): job#${String(jobId)}`
+            )
+            return
+          }
+          if (!activeJobIds().has(jobId)) {
+            console.log(
+              `[job-chain] poll result discarded (not in activeJobIds): job#${String(jobId)} activeIds=${JSON.stringify([...activeJobIds()])}`
+            )
+            return
+          }
 
           const shouldContinue = handlePolledJob(job)
           if (shouldContinue) {
@@ -183,13 +276,27 @@ export function createJobTracker(options: JobTrackerOptions) {
     poll()
   }
 
-  // Route/entity changes in a reused component instance should not keep old local jobs active.
+  // Stop only when navigating to a different entity (ID changed from one defined value to another).
+  // Do NOT stop when an ID first becomes defined — that's new data arriving (e.g. lecture created),
+  // not navigation, and killing the tracker here would drop child-job polling.
   createEffect(
     on(
       () => [options.topicId?.(), options.lectureId?.(), options.courseId?.()] as const,
-      () => {
-        stop()
-        setLastError(null)
+      ([newTopicId, newLectureId, newCourseId], prev) => {
+        const [prevTopicId, prevLectureId, prevCourseId] = prev ?? [undefined, undefined, undefined]
+        const navigated = (p: number | undefined, n: number | undefined) =>
+          p != null && n != null && p !== n
+        if (
+          navigated(prevTopicId, newTopicId) ||
+          navigated(prevLectureId, newLectureId) ||
+          navigated(prevCourseId, newCourseId)
+        ) {
+          console.log(
+            `[job-chain] entity navigation detected (prev=[${String(prevTopicId)},${String(prevLectureId)},${String(prevCourseId)}] → next=[${String(newTopicId)},${String(newLectureId)},${String(newCourseId)}]), stopping tracker`
+          )
+          stop()
+          setLastError(null)
+        }
       },
       { defer: true }
     )


### PR DESCRIPTION
This pull request introduces support for parent-child relationships between jobs in the system. The main changes add a `parent_job_id` field to the `jobs` table and propagate this relationship throughout the API, models, job services, and job enqueueing logic. This enables tracking and querying jobs that are spawned as part of other jobs, and exposes new endpoints for retrieving child jobs.

**Database and Model Changes:**

* Added a nullable `parent_job_id` column to the `jobs` table with a foreign key constraint and index, and updated the `JobModel` SQLAlchemy model accordingly. [[1]](diffhunk://#diff-f24c238fc763a84490e27eafac52dfed3f5e22ecc2e005f8d387c99b3937f5faR1-R29) [[2]](diffhunk://#diff-177cff92b3693efde4e2da322e8931bffea0b172e4c963bea74609a44b860fc7R229-R236)

**API and Query Enhancements:**

* Updated job-related API endpoints to include `parent_job_id` in job responses, allow filtering jobs by `parent_id`, and added a new endpoint to list child jobs of a given job. [[1]](diffhunk://#diff-919d4b0627e8c740bc4192848693399f92eaadca9be7eeed0e421ffde8d319b2R47) [[2]](diffhunk://#diff-919d4b0627e8c740bc4192848693399f92eaadca9be7eeed0e421ffde8d319b2R139) [[3]](diffhunk://#diff-919d4b0627e8c740bc4192848693399f92eaadca9be7eeed0e421ffde8d319b2R150) [[4]](diffhunk://#diff-919d4b0627e8c740bc4192848693399f92eaadca9be7eeed0e421ffde8d319b2L230-R245)

**Repository and Service Updates:**

* Modified the job repository and service layers to accept and propagate `parent_job_id` when creating and listing jobs, ensuring the parent-child relationship is stored and queryable. [[1]](diffhunk://#diff-6849a94f12ef8df10fd3ff8ab56995ef04db9ad258afd28d5639844b4d3f28ffR27) [[2]](diffhunk://#diff-6849a94f12ef8df10fd3ff8ab56995ef04db9ad258afd28d5639844b4d3f28ffR38) [[3]](diffhunk://#diff-6849a94f12ef8df10fd3ff8ab56995ef04db9ad258afd28d5639844b4d3f28ffR58-R67) [[4]](diffhunk://#diff-ae0594cd24a07b07b63cd2067d79e2551e6fc9a024ac3040de10e03ad30778afL49-R54) [[5]](diffhunk://#diff-ae0594cd24a07b07b63cd2067d79e2551e6fc9a024ac3040de10e03ad30778afL64-R69)

**Job Enqueueing Improvements:**

* Refactored all job enqueue methods in `JobEnqueueService` to accept an optional `parent_job_id` parameter, passing it down when creating jobs. Now, all jobs spawned by the service can be linked to a parent job. [[1]](diffhunk://#diff-b9ed5180647b74d44c8f16127e91c3ba9011b0a08e559a7ddf2f37cf53ca8cbaR9) [[2]](diffhunk://#diff-b9ed5180647b74d44c8f16127e91c3ba9011b0a08e559a7ddf2f37cf53ca8cbaL23-R46) [[3]](diffhunk://#diff-b9ed5180647b74d44c8f16127e91c3ba9011b0a08e559a7ddf2f37cf53ca8cbaL67-R208)

**Worker and Course Service Integration:**

* Updated job dispatching and course creation flows so that jobs created as a result of other jobs (e.g., image generation after course creation) can be linked as children of the initiating job. [[1]](diffhunk://#diff-64529b5bedd7c63658a120e75d850a82c65daa4613aed640c75f5867e3a1c991L316-R316) [[2]](diffhunk://#diff-f7c4763125f9615cce306438b88a2f9929e157b32e759075a616248c9e1e06dfR69) [[3]](diffhunk://#diff-f7c4763125f9615cce306438b88a2f9929e157b32e759075a616248c9e1e06dfL120-R121) [[4]](diffhunk://#diff-f7c4763125f9615cce306438b88a2f9929e157b32e759075a616248c9e1e06dfL187-R200)

These changes collectively enable hierarchical job tracking and make it easier to manage and observe complex workflows involving multiple interdependent jobs.