### PR TITLE
Add xAI (Grok) as a third TTS backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/artificial_u_dev
 ANTHROPIC_API_KEY=
 ELEVENLABS_API_KEY=
 MISTRAL_API_KEY=
+XAI_API_KEY=
 GOOGLE_API_KEY=
 OPENAI_API_KEY=
 

--- a/.env.test
+++ b/.env.test
@@ -5,6 +5,7 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/artificial_u_test
 ANTHROPIC_API_KEY=test_anthropic_key
 ELEVENLABS_API_KEY=test_elevenlabs_key
 MISTRAL_API_KEY=test_mistral_key
+XAI_API_KEY=test_xai_key
 GOOGLE_API_KEY=test_google_key
 OPENAI_API_KEY=test_openai_key
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -273,6 +273,7 @@ When adding frontend features:
 - `ANTHROPIC_API_KEY`: Anthropic Claude API key
 - `ELEVENLABS_API_KEY`: ElevenLabs TTS API key
 - `MISTRAL_API_KEY`: Mistral API key (TTS when using Mistral backend)
+- `XAI_API_KEY`: xAI API key (TTS when using xAI/Grok backend)
 - `DATABASE_URL`: PostgreSQL connection string
 - `AUTH0_DOMAIN`, `AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`: Auth0 configuration
 - `MINIO_*` or `AWS_*`: Storage configuration

--- a/.github/workflows/test-quick.yml
+++ b/.github/workflows/test-quick.yml
@@ -48,6 +48,7 @@ jobs:
           ANTHROPIC_API_KEY=test_anthropic_key
           ELEVENLABS_API_KEY=test_elevenlabs_key
           MISTRAL_API_KEY=test_mistral_key
+          XAI_API_KEY=test_xai_key
           GOOGLE_API_KEY=test_google_key
           OPENAI_API_KEY=test_openai_key
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,6 +127,7 @@ jobs:
           ANTHROPIC_API_KEY=test_anthropic_key
           ELEVENLABS_API_KEY=test_elevenlabs_key
           MISTRAL_API_KEY=test_mistral_key
+          XAI_API_KEY=test_xai_key
           GOOGLE_API_KEY=test_google_key
           OPENAI_API_KEY=test_openai_key
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -338,6 +338,7 @@ Required in `.env` file:
 - `ANTHROPIC_API_KEY`: Anthropic Claude API key
 - `ELEVENLABS_API_KEY`: ElevenLabs TTS API key
 - `MISTRAL_API_KEY`: Mistral API key (TTS when using Mistral backend)
+- `XAI_API_KEY`: xAI API key (TTS when using xAI/Grok backend)
 - `DATABASE_URL`: PostgreSQL connection string
 - `AUTH0_DOMAIN`, `AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`: Auth0 configuration
 - `MINIO_*` or `AWS_*`: Storage configuration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,6 +338,7 @@ Required in `.env` file:
 - `ANTHROPIC_API_KEY`: Anthropic Claude API key
 - `ELEVENLABS_API_KEY`: ElevenLabs TTS API key
 - `MISTRAL_API_KEY`: Mistral API key (TTS when using Mistral backend)
+- `XAI_API_KEY`: xAI API key (TTS when using xAI/Grok backend)
 - `DATABASE_URL`: PostgreSQL connection string
 - `AUTH0_DOMAIN`, `AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`: Auth0 configuration
 - `MINIO_*` or `AWS_*`: Storage configuration

--- a/artificial_u/__main__.py
+++ b/artificial_u/__main__.py
@@ -29,6 +29,8 @@ def check_api_keys():
         optional_missing.append("ELEVENLABS_API_KEY")
     if not os.environ.get("MISTRAL_API_KEY"):
         optional_missing.append("MISTRAL_API_KEY")
+    if not os.environ.get("XAI_API_KEY"):
+        optional_missing.append("XAI_API_KEY")
     if not os.environ.get("GOOGLE_API_KEY"):
         optional_missing.append("GOOGLE_API_KEY")
     if not os.environ.get("OPENAI_API_KEY"):

--- a/artificial_u/api/routers/voices.py
+++ b/artificial_u/api/routers/voices.py
@@ -341,6 +341,74 @@ async def list_mistral_catalog(
 
 
 # ---------------------------------------------------------------------------
+# xAI voice catalog (on-demand from the xAI API)
+# ---------------------------------------------------------------------------
+
+
+class XaiVoiceCatalogItem(BaseModel):
+    """A voice from the xAI API, mapped into a shape the frontend can use."""
+
+    id: str = Field(..., description="xAI voice id (e.g. 'eve', 'camille')")
+    name: str = Field(..., description="Display name")
+    language: Optional[str] = None
+    gender: Optional[str] = None
+
+
+class XaiVoiceCatalogResponse(BaseModel):
+    items: list[XaiVoiceCatalogItem]
+    total: int
+
+
+@router.get(
+    "/xai/catalog",
+    response_model=XaiVoiceCatalogResponse,
+    dependencies=[Depends(require_auth)],
+)
+async def list_xai_catalog(
+    language: Optional[str] = Query(None, description="Filter by language prefix (e.g. 'fr')"),
+    gender: Optional[str] = Query(None, description="Filter by gender"),
+):
+    """
+    List voices directly from the xAI Voices API.
+
+    These are **not** stored in our database. The frontend uses the xAI voice
+    ``id`` as the ``voice_id`` when previewing or assigning. The catalog is read
+    fresh each time so newly added xAI voices appear automatically.
+    """
+    try:
+        from artificial_u.integrations.xai.voice_manager import XAIVoiceManager
+
+        mgr = XAIVoiceManager()
+        raw_voices = mgr.list_voices()
+    except Exception as e:
+        logger.error("Failed to fetch xAI voice catalog: %s", e)
+        raise HTTPException(status_code=502, detail=f"xAI API error: {e}")
+
+    items: list[XaiVoiceCatalogItem] = []
+    for v in raw_voices:
+        if not v.get("id"):
+            continue
+        # Optional client-side filters
+        if language:
+            lang = v.get("language") or ""
+            if not str(lang).startswith(language):
+                continue
+        if gender and v.get("gender") != gender:
+            continue
+
+        items.append(
+            XaiVoiceCatalogItem(
+                id=v["id"],
+                name=v.get("name") or v["id"],
+                language=v.get("language"),
+                gender=v.get("gender"),
+            )
+        )
+
+    return XaiVoiceCatalogResponse(items=items, total=len(items))
+
+
+# ---------------------------------------------------------------------------
 # Voice preview (TTS sample generation)
 # ---------------------------------------------------------------------------
 

--- a/artificial_u/audio/speech_processor.py
+++ b/artificial_u/audio/speech_processor.py
@@ -25,19 +25,50 @@ class SpeechProcessor:
         """
         self.logger = logger or logging.getLogger(__name__)
 
-    def normalize_text(self, text: str, supports_ssml: bool = True) -> str:
+    def normalize_text(self, text: str, backend_name: str = "elevenlabs") -> str:
         """
-        Normalize text for TTS without aggressive markup.
-        This is a light-touch normalization focused on common issues.
+        Normalize text for TTS using an explicit per-backend processing path.
+
+        Applies shared light-touch normalization, then dispatches to the
+        backend-specific handler for pause / stage-direction markup. There is
+        no "generic" path: each backend gets explicit treatment.
 
         Args:
-            text: The text to normalize
-            supports_ssml: Whether the TTS backend supports SSML-like tags
-                (e.g., <break> tags). Defaults to True for ElevenLabs
-                compatibility. Set to False for backends like Mistral.
+            text: The text to normalize.
+            backend_name: TTS backend the text is destined for
+                ("elevenlabs", "mistral", "xai"). Unknown backends fall back to
+                clean prose (pause directions stripped, no markup).
 
         Returns:
-            Normalized text suitable for TTS
+            Normalized text suitable for the given TTS backend.
+        """
+        normalized_text = self._normalize_common(text)
+
+        if backend_name == "elevenlabs":
+            # SSML-capable: convert pause directions to <break> tags.
+            normalized_text = self._convert_pauses(normalized_text, mode="ssml")
+        elif backend_name == "xai":
+            # xAI markup: [pause]/[long-pause] tags + <soft> stage directions.
+            normalized_text = self._process_xai(normalized_text)
+        elif backend_name == "mistral":
+            # No markup support: strip bracketed pause directions entirely.
+            normalized_text = self._strip_pause_directions(normalized_text)
+        else:
+            self.logger.debug(
+                "Unknown TTS backend %r; defaulting to clean-prose processing",
+                backend_name,
+            )
+            normalized_text = self._strip_pause_directions(normalized_text)
+
+        return normalized_text.strip()
+
+    def _normalize_common(self, text: str) -> str:
+        """
+        Backend-agnostic light-touch normalization shared by all backends.
+
+        Handles hyphenation, dashes (preserving math), markdown headers,
+        whitespace, and appending periods to unpunctuated lines. Does NOT
+        touch pause / stage-direction markup — that is backend-specific.
         """
 
         def _append_period_to_unpunctuated_lines(s: str) -> str:
@@ -104,31 +135,32 @@ class SpeechProcessor:
         # Remove markdown title prefixes
         normalized_text = re.sub(r"^#+\s+", "", normalized_text, flags=re.MULTILINE)
 
-        # Apply pause conversions for bracketed stage directions
-        if supports_ssml:
-            # Convert to <break> SSML tags (ElevenLabs and other SSML-capable backends)
-            normalized_text = self._apply_pause_breaks(normalized_text)
-        else:
-            # For non-SSML backends, strip stage direction brackets entirely
-            normalized_text = self._strip_pause_directions(normalized_text)
+        return normalized_text
 
-        return normalized_text.strip()
+    def _convert_pauses(self, text: str, mode: str = "ssml") -> str:
+        """Convert bracketed pause stage directions to backend-specific markup.
 
-    def _apply_pause_breaks(self, text: str) -> str:
-        """Convert bracketed pause stage directions to ElevenLabs <break> tags.
+        ``mode="ssml"`` renders ElevenLabs ``<break time="Xs" />`` tags;
+        ``mode="xai"`` renders xAI ``[pause]`` / ``[long-pause]`` inline tags
+        (short pauses ≤1.0s → ``[pause]``; longer / duration pauses → ``[long-pause]``).
 
         Rules (case-insensitive):
-        - [Pause] → <break time="1.0s" />
-        - [Slight pause] → <break time="0.5s" />
-        - [Slight pause for ...] → <break time="1.0s" /> (special case)
-        - [Pause for ...] (e.g., emphasis/effect/a moment) → <break time="1.5s" />
-        - [Brief pause ...] → <break time="0.5s" />
-        - [Pauses thoughtfully] → <break time="1.5s" />
-        - [Pause, ...] or [Pauses, ...] → <break time="1.0s" /> (general pause with description)
+        - [Pause] → 1.0s break / [pause]
+        - [Slight pause] → 0.5s break / [pause]
+        - [Slight pause for ...] → 1.0s break / [pause] (special case)
+        - [Pause for ...] (e.g., emphasis/effect/a moment) → 1.5s break / [long-pause]
+        - [Brief pause ...] → 0.5s break / [pause]
+        - [Pauses thoughtfully] → 1.5s break / [long-pause]
+        - [Pause, ...] or [Pauses, ...] → 1.0s break / [pause] (general pause with description)
+        - [Pauses for N seconds] → dynamic break / [long-pause]
         - [Pauses at ...] is left unchanged
         """
 
+        is_xai = mode == "xai"
+
         def _pause_for_seconds_repl(match: re.Match) -> str:
+            if is_xai:
+                return " [long-pause] "
             raw = match.group(1).strip().lower()
             raw = re.sub(r"[.?!]+$", "", raw).strip()
 
@@ -169,26 +201,26 @@ class SpeechProcessor:
             flags=re.IGNORECASE,
         )
 
-        # [Slight pause, ...] → 0.5s + keep remainder as bracketed comment
+        # [Slight pause, ...] → short + keep remainder as bracketed comment
         text = re.sub(
             r"\[\s*slight\s+pause\s*,\s*([^\]]+)\]",
-            r' <break time="0.5s" /> [\1] ',
+            (r" [pause] [\1] " if is_xai else r' <break time="0.5s" /> [\1] '),
             text,
             flags=re.IGNORECASE,
         )
 
-        # [Brief pause, ...] → 0.5s + keep remainder as bracketed comment
+        # [Brief pause, ...] → short + keep remainder as bracketed comment
         text = re.sub(
             r"\[\s*brief\s+pause\s*,\s*([^\]]+)\]",
-            r' <break time="0.5s" /> [\1] ',
+            (r" [pause] [\1] " if is_xai else r' <break time="0.5s" /> [\1] '),
             text,
             flags=re.IGNORECASE,
         )
 
-        # [Pause, ...] or [Pauses, ...] → 1.0s (target comma variants)
+        # [Pause, ...] or [Pauses, ...] → short (target comma variants)
         text = re.sub(
             r"\[\s*pauses?\s*,[^\]]*\]",
-            ' <break time="1.0s" /> ',
+            (" [pause] " if is_xai else ' <break time="1.0s" /> '),
             text,
             flags=re.IGNORECASE,
         )
@@ -198,7 +230,7 @@ class SpeechProcessor:
         # Exact [Slight pause]
         text = re.sub(
             r"\[\s*slight\s+pause\s*\]",
-            ' <break time="0.5s" /> ',
+            (" [pause] " if is_xai else ' <break time="0.5s" /> '),
             text,
             flags=re.IGNORECASE,
         )
@@ -206,54 +238,80 @@ class SpeechProcessor:
         # Exact [Pause]
         text = re.sub(
             r"\[\s*pause\s*\]",
-            ' <break time="1.0s" /> ',
+            (" [pause] " if is_xai else ' <break time="1.0s" /> '),
             text,
             flags=re.IGNORECASE,
         )
 
-        # [Pauses thoughtfully] → 1.5s
+        # [Pauses thoughtfully] → long
         text = re.sub(
             r"\[\s*pauses\s+thoughtfully\s*\]",
-            ' <break time="1.5s" /> ',
+            (" [long-pause] " if is_xai else ' <break time="1.5s" /> '),
             text,
             flags=re.IGNORECASE,
         )
 
         # Process more general patterns last
 
-        # [Slight pause for X...] → 1.0s (special case for "slight pause for")
+        # [Slight pause for X...] → short (special case for "slight pause for")
         text = re.sub(
             r"\[\s*slight\s+pause\s+for\s+[^\]]+\]",
-            ' <break time="1.0s" /> ',
+            (" [pause] " if is_xai else ' <break time="1.0s" /> '),
             text,
             flags=re.IGNORECASE,
         )
 
-        # [Pause for X...] (emphasis, effect, a moment, etc.) → 1.5s
+        # [Pause for X...] (emphasis, effect, a moment, etc.) → long
         text = re.sub(
             r"\[\s*pause\s+for\s+[^\]]+\]",
-            ' <break time="1.5s" /> ',
+            (" [long-pause] " if is_xai else ' <break time="1.5s" /> '),
             text,
             flags=re.IGNORECASE,
         )
 
-        # [Slight pause ...] → 0.5s (general case, after comma variant)
+        # [Slight pause ...] → short (general case, after comma variant)
         text = re.sub(
             r"\[\s*slight\s+pause[^\]]*\]",
-            ' <break time="0.5s" /> ',
+            (" [pause] " if is_xai else ' <break time="0.5s" /> '),
             text,
             flags=re.IGNORECASE,
         )
 
-        # [Brief pause ...] → 0.5s (general case, after comma variant)
+        # [Brief pause ...] → short (general case, after comma variant)
         text = re.sub(
             r"\[\s*brief\s+pause[^\]]*\]",
-            ' <break time="0.5s" /> ',
+            (" [pause] " if is_xai else ' <break time="0.5s" /> '),
             text,
             flags=re.IGNORECASE,
         )
 
         # Collapse any excess whitespace again after insertions
+        text = re.sub(r"[ \t]+", " ", text)
+        return text
+
+    def _process_xai(self, text: str) -> str:
+        """Process text for xAI Grok markup.
+
+        Converts pause stage directions to ``[pause]`` / ``[long-pause]`` inline
+        tags, then wraps any remaining bracketed stage directions (e.g.
+        ``[walks to the front]``) in ``<soft>...</soft>``. A single trailing
+        period inserted by common normalization is dropped from inside the wrap.
+        """
+        text = self._convert_pauses(text, mode="xai")
+
+        def _wrap_soft(match: re.Match) -> str:
+            inner = match.group(1).rstrip()
+            # Drop a single trailing period added by line normalization.
+            if inner.endswith(".") and not inner.endswith(".."):
+                inner = inner[:-1].rstrip()
+            return f"<soft>{inner}</soft>"
+
+        # Wrap remaining bracketed directions, but never the [pause]/[long-pause] tags.
+        text = re.sub(
+            r"\[(?!pause\]|long-pause\])([^\[\]]+)\]",
+            _wrap_soft,
+            text,
+        )
         text = re.sub(r"[ \t]+", " ", text)
         return text
 

--- a/artificial_u/cli.py
+++ b/artificial_u/cli.py
@@ -33,6 +33,7 @@ def get_system():
         anthropic_key = os.environ.get("ANTHROPIC_API_KEY")
         elevenlabs_key = os.environ.get("ELEVENLABS_API_KEY")
         mistral_key = os.environ.get("MISTRAL_API_KEY")
+        xai_key = os.environ.get("XAI_API_KEY")
         google_key = os.environ.get("GOOGLE_API_KEY")
         openai_key = os.environ.get("OPENAI_API_KEY")
 
@@ -40,6 +41,7 @@ def get_system():
             anthropic_api_key=anthropic_key,
             elevenlabs_api_key=elevenlabs_key,
             mistral_api_key=mistral_key,
+            xai_api_key=xai_key,
             google_api_key=google_key,
             openai_api_key=openai_key,
             db_url=os.environ.get("DATABASE_URL"),

--- a/artificial_u/config/defaults.py
+++ b/artificial_u/config/defaults.py
@@ -20,6 +20,8 @@ DEFAULT_CONTENT_LOGS_PATH = "content_logs"
 
 # TTS defaults
 DEFAULT_TTS_BACKEND = "elevenlabs"
+DEFAULT_XAI_TTS_BASE_URL = "https://api.x.ai/v1"
+DEFAULT_XAI_TTS_LANGUAGE = "en"
 
 # Storage defaults (MinIO/S3)
 DEFAULT_STORAGE_TYPE = "minio"  # "minio" or "s3"

--- a/artificial_u/config/settings.py
+++ b/artificial_u/config/settings.py
@@ -275,6 +275,7 @@ class Settings(BaseSettings):
             "tts_backend": self.tts_backend,
             "elevenlabs_api_key": self.ELEVENLABS_API_KEY,
             "mistral_api_key": self.MISTRAL_API_KEY,
+            "xai_api_key": self.XAI_API_KEY,
             "google_api_key": self.GOOGLE_API_KEY,
             "openai_api_key": self.OPENAI_API_KEY,
             "storage_type": self.STORAGE_TYPE,

--- a/artificial_u/config/settings.py
+++ b/artificial_u/config/settings.py
@@ -36,6 +36,8 @@ from artificial_u.config.defaults import (
     DEFAULT_STORAGE_REGION,
     DEFAULT_STORAGE_TYPE,
     DEFAULT_TTS_BACKEND,
+    DEFAULT_XAI_TTS_BASE_URL,
+    DEFAULT_XAI_TTS_LANGUAGE,
 )
 
 
@@ -96,6 +98,7 @@ class Settings(BaseSettings):
     ELEVENLABS_API_KEY: Optional[str] = None
     GOOGLE_API_KEY: Optional[str] = None
     OPENAI_API_KEY: Optional[str] = None
+    XAI_API_KEY: Optional[str] = None
 
     # Auth0 (API resource protection)
     AUTH0_DOMAIN: Optional[str] = None
@@ -145,13 +148,17 @@ class Settings(BaseSettings):
     LECTURE_IMAGE_INTERVAL_SEC: int = DEFAULT_LECTURE_IMAGE_INTERVAL_SEC
 
     # Text-to-speech settings
-    tts_backend: str = DEFAULT_TTS_BACKEND  # "elevenlabs" or "mistral"
+    tts_backend: str = DEFAULT_TTS_BACKEND  # "elevenlabs", "mistral", or "xai"
     # ElevenLabs voice model. Example values: "eleven_flash_v2_5", "eleven_multilingual_v2"
     TTS_VOICE_MODEL: str = "eleven_flash_v2_5"
     # Mistral TTS model
     TTS_MISTRAL_MODEL: str = "voxtral-mini-tts-2603"
     # Mistral API key (optional, required only if tts_backend="mistral")
     MISTRAL_API_KEY: Optional[str] = None
+    # xAI (Grok) TTS settings (used only if tts_backend="xai")
+    XAI_TTS_BASE_URL: str = DEFAULT_XAI_TTS_BASE_URL
+    # Default output language (BCP-47 code) for backends that accept one (e.g. xAI)
+    XAI_TTS_LANGUAGE: str = DEFAULT_XAI_TTS_LANGUAGE
 
     # Coin costs for generation operations (can be tuned via environment variables)
     COIN_COST_COURSE_GENERATION: int = 1

--- a/artificial_u/integrations/tts/base.py
+++ b/artificial_u/integrations/tts/base.py
@@ -39,7 +39,3 @@ class TTSBackend(Protocol):
     def default_voice_settings(self) -> Dict[str, Any]:
         """Return default voice settings for this backend."""
         ...
-
-    def supports_ssml(self) -> bool:
-        """Whether this backend supports SSML-like markup (e.g., <break> tags)."""
-        ...

--- a/artificial_u/integrations/tts/elevenlabs_backend.py
+++ b/artificial_u/integrations/tts/elevenlabs_backend.py
@@ -40,9 +40,6 @@ class ElevenLabsTTSBackend:
     def default_voice_settings(self) -> Dict[str, Any]:
         return self.DEFAULT_VOICE_SETTINGS.copy()
 
-    def supports_ssml(self) -> bool:
-        return True
-
     def text_to_speech(
         self,
         text: str,

--- a/artificial_u/integrations/tts/factory.py
+++ b/artificial_u/integrations/tts/factory.py
@@ -17,7 +17,7 @@ def create_tts_backend(
     """Create a TTS backend instance.
 
     Args:
-        backend_name: Backend to use ("elevenlabs", "mistral").
+        backend_name: Backend to use ("elevenlabs", "mistral", "xai").
             Defaults to settings.tts_backend.
         api_key: Optional API key override.
         logger: Optional logger.
@@ -45,7 +45,15 @@ def create_tts_backend(
             api_key=api_key or settings.MISTRAL_API_KEY,
             logger=logger,
         )
+    elif backend_name == "xai":
+        from artificial_u.integrations.tts.xai_backend import XAITTSBackend
+
+        return XAITTSBackend(
+            api_key=api_key or settings.XAI_API_KEY,
+            logger=logger,
+        )
     else:
         raise ValueError(
-            f"Unknown TTS backend: '{backend_name}'. " "Supported backends: 'elevenlabs', 'mistral'"
+            f"Unknown TTS backend: '{backend_name}'. "
+            "Supported backends: 'elevenlabs', 'mistral', 'xai'"
         )

--- a/artificial_u/integrations/tts/mistral_backend.py
+++ b/artificial_u/integrations/tts/mistral_backend.py
@@ -36,9 +36,6 @@ class MistralTTSBackend:
     def default_voice_settings(self) -> Dict[str, Any]:
         return {}
 
-    def supports_ssml(self) -> bool:
-        return False
-
     def text_to_speech(
         self,
         text: str,

--- a/artificial_u/integrations/tts/xai_backend.py
+++ b/artificial_u/integrations/tts/xai_backend.py
@@ -1,0 +1,70 @@
+"""
+xAI (Grok) TTS backend adapter.
+
+Wraps XAITTSClient to conform to the TTSBackend protocol.
+"""
+
+import logging
+from typing import Any, Dict, Optional
+
+from artificial_u.config import get_settings
+from artificial_u.integrations.xai.tts_client import XAITTSClient
+
+
+class XAITTSBackend:
+    """TTS backend implementation for xAI Grok."""
+
+    DEFAULT_VOICE = "eve"
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        client: Optional[XAITTSClient] = None,
+        logger: Optional[logging.Logger] = None,
+    ):
+        self.logger = logger or logging.getLogger(__name__)
+        settings = get_settings()
+        api_key = api_key or getattr(settings, "XAI_API_KEY", None)
+        self._client = client or XAITTSClient(
+            api_key=api_key,
+            base_url=getattr(settings, "XAI_TTS_BASE_URL", None),
+            logger=self.logger,
+        )
+        self._settings = settings
+
+    @property
+    def backend_name(self) -> str:
+        return "xai"
+
+    @property
+    def default_voice_settings(self) -> Dict[str, Any]:
+        return {}
+
+    def text_to_speech(
+        self,
+        text: str,
+        voice_id: str,
+        **kwargs: Any,
+    ) -> bytes:
+        """Convert text to speech using xAI Grok.
+
+        Args:
+            text: Text to convert.
+            voice_id: Built-in xAI voice name (ara, eve, leo, rex, sal).
+            **kwargs: Optional overrides:
+                - language: BCP-47 language code (defaults to settings.XAI_TTS_LANGUAGE).
+                - output_format: Codec/sample-rate/bit-rate dict.
+
+        Returns:
+            Audio data as bytes.
+        """
+        effective_voice_id = voice_id or self.DEFAULT_VOICE
+        language = kwargs.get("language") or getattr(self._settings, "XAI_TTS_LANGUAGE", "en")
+        output_format = kwargs.get("output_format")
+
+        return self._client.text_to_speech(
+            text=text,
+            voice_id=effective_voice_id,
+            language=language,
+            output_format=output_format,
+        )

--- a/artificial_u/integrations/xai/__init__.py
+++ b/artificial_u/integrations/xai/__init__.py
@@ -1,0 +1,1 @@
+"""xAI (Grok) integration package."""

--- a/artificial_u/integrations/xai/tts_client.py
+++ b/artificial_u/integrations/xai/tts_client.py
@@ -1,0 +1,138 @@
+"""
+xAI (Grok) TTS client.
+
+Wraps the xAI text-to-speech REST endpoint (POST {base_url}/tts), which returns
+raw audio bytes (mp3 by default). Uses httpx directly rather than an SDK.
+"""
+
+import logging
+import os
+import sys
+import time
+from typing import Any, Dict, Optional
+
+import httpx
+
+from artificial_u.config import get_settings
+
+
+class XAITTSClient:
+    """Low-level client for the xAI Grok text-to-speech API."""
+
+    # Default built-in voice (one of: ara, eve, leo, rex, sal)
+    DEFAULT_VOICE = "eve"
+    DEFAULT_LANGUAGE = "en"
+    DEFAULT_OUTPUT_FORMAT: Dict[str, Any] = {
+        "codec": "mp3",
+        "sample_rate": 24000,
+        "bit_rate": 128000,
+    }
+
+    MAX_RETRIES = 3
+    RETRY_WAIT = 2
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        logger: Optional[logging.Logger] = None,
+    ):
+        """Initialize the xAI TTS client.
+
+        Args:
+            api_key: xAI API key. Falls back to XAI_API_KEY env/settings.
+            base_url: Override the xAI API base URL.
+            logger: Optional logger.
+        """
+        self.logger = logger or logging.getLogger(__name__)
+        settings = get_settings()
+
+        in_test_env = os.environ.get("TESTING") == "true" or "pytest" in sys.modules
+
+        self.api_key = api_key or os.environ.get("XAI_API_KEY") or settings.XAI_API_KEY
+        if not self.api_key:
+            if in_test_env:
+                self.api_key = "test_xai_key"
+                self.logger.info("Using test API key in test environment")
+            else:
+                raise ValueError("xAI API key is required for TTS")
+
+        self.base_url = (base_url or settings.XAI_TTS_BASE_URL).rstrip("/")
+
+    def text_to_speech(
+        self,
+        text: str,
+        voice_id: str = DEFAULT_VOICE,
+        language: Optional[str] = None,
+        output_format: Optional[Dict[str, Any]] = None,
+    ) -> bytes:
+        """Convert text to speech via the xAI TTS endpoint.
+
+        Args:
+            text: Text to convert.
+            voice_id: Built-in xAI voice name (ara, eve, leo, rex, sal).
+            language: BCP-47 language code (default: "en").
+            output_format: Codec/sample-rate/bit-rate dict. Defaults to mp3.
+
+        Returns:
+            Audio data as bytes (mp3 by default).
+        """
+        effective_voice_id = voice_id or self.DEFAULT_VOICE
+        body: Dict[str, Any] = {
+            "text": text,
+            "voice_id": effective_voice_id,
+            "language": language or self.DEFAULT_LANGUAGE,
+            "output_format": output_format or dict(self.DEFAULT_OUTPUT_FORMAT),
+        }
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        url = f"{self.base_url}/tts"
+
+        for attempt in range(self.MAX_RETRIES):
+            try:
+                self.logger.debug(
+                    "xAI TTS attempt %d: voice_id=%s, text_len=%d",
+                    attempt + 1,
+                    effective_voice_id,
+                    len(text),
+                )
+                with httpx.Client(timeout=120) as http:
+                    response = http.post(url, json=body, headers=headers)
+                    response.raise_for_status()
+                    audio_data = response.content
+
+                if len(audio_data) < 1000 and len(text) > 100:
+                    self.logger.warning(
+                        "Unexpectedly small audio from xAI: %d bytes for %d chars",
+                        len(audio_data),
+                        len(text),
+                    )
+                return audio_data
+
+            except httpx.HTTPStatusError as e:
+                # Error responses are JSON even though success is raw bytes.
+                self.logger.error(
+                    "xAI TTS HTTP error (attempt %d): %s - %s",
+                    attempt + 1,
+                    e,
+                    e.response.text if e.response is not None else "",
+                )
+                if attempt < self.MAX_RETRIES - 1:
+                    wait = self.RETRY_WAIT * (attempt + 1)
+                    self.logger.info("Waiting %ds before retry...", wait)
+                    time.sleep(wait)
+                    continue
+                raise
+            except Exception as e:
+                self.logger.error("xAI TTS error (attempt %d): %s", attempt + 1, e)
+                if attempt < self.MAX_RETRIES - 1:
+                    wait = self.RETRY_WAIT * (attempt + 1)
+                    self.logger.info("Waiting %ds before retry...", wait)
+                    time.sleep(wait)
+                    continue
+                raise
+
+        # Should not reach here, but satisfy type checker
+        raise RuntimeError("xAI TTS failed after all retries")

--- a/artificial_u/integrations/xai/voice_manager.py
+++ b/artificial_u/integrations/xai/voice_manager.py
@@ -1,33 +1,96 @@
 """
-xAI (Grok) voice catalog.
+xAI (Grok) voice manager.
 
-Non-enterprise xAI accounts cannot clone or create voices and there is no
-public list-voices endpoint, so the catalog is a small, static, curated set of
-the built-in voices. This module is the single source of truth shared by the
-seed script (and any future catalog endpoint).
+Lists the available xAI voices from the live API (GET {base}/tts/voices).
+xAI exposes a small, evolving catalog (a handful of multilingual voices plus
+language-specific voices). We always read it fresh so new voices appear
+automatically without code changes. Non-enterprise accounts cannot create
+custom voices, so this is read-only.
 """
 
 import logging
+import os
+import sys
+import time
 from typing import Any, Dict, List, Optional
 
-# Built-in xAI voices. Metadata (gender in particular) is curated/best-effort and
-# safe to refine; the UI tolerates a null gender. All voices speak English and
-# can be used for accented-English output regardless of intended language.
-XAI_VOICES: List[Dict[str, Any]] = [
-    {"id": "eve", "name": "Eve", "gender": "female", "language": "en"},
-    {"id": "ara", "name": "Ara", "gender": "female", "language": "en"},
-    {"id": "leo", "name": "Leo", "gender": "male", "language": "en"},
-    {"id": "rex", "name": "Rex", "gender": "male", "language": "en"},
-    {"id": "sal", "name": "Sal", "gender": "male", "language": "en"},
-]
+import httpx
+
+from artificial_u.config import get_settings
 
 
 class XAIVoiceManager:
-    """Provides the static xAI voice catalog (mirrors the Mistral voice manager API)."""
+    """Reads the xAI voice catalog from the live API."""
 
-    def __init__(self, logger: Optional[logging.Logger] = None):
+    MAX_RETRIES = 3
+    RETRY_WAIT = 2
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        logger: Optional[logging.Logger] = None,
+    ):
         self.logger = logger or logging.getLogger(__name__)
+        settings = get_settings()
+
+        in_test_env = os.environ.get("TESTING") == "true" or "pytest" in sys.modules
+
+        self.api_key = api_key or os.environ.get("XAI_API_KEY") or settings.XAI_API_KEY
+        if not self.api_key:
+            if in_test_env:
+                self.api_key = "test_xai_key"
+            else:
+                raise ValueError("xAI API key is required for voice management")
+
+        self.base_url = (base_url or settings.XAI_TTS_BASE_URL).rstrip("/")
 
     def list_voices(self) -> List[Dict[str, Any]]:
-        """Return the static list of built-in xAI voices."""
-        return [dict(v) for v in XAI_VOICES]
+        """List available xAI voices.
+
+        Returns:
+            List of voice dicts normalized to: id, name, language, gender.
+        """
+        url = f"{self.base_url}/tts/voices"
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+
+        last_exc: Optional[Exception] = None
+        for attempt in range(self.MAX_RETRIES):
+            try:
+                with httpx.Client(timeout=30) as http:
+                    response = http.get(url, headers=headers)
+                    response.raise_for_status()
+                    payload = response.json()
+                break
+            except Exception as e:
+                last_exc = e
+                self.logger.error("xAI list voices error (attempt %d): %s", attempt + 1, e)
+                if attempt < self.MAX_RETRIES - 1:
+                    time.sleep(self.RETRY_WAIT * (attempt + 1))
+                    continue
+                raise
+        else:  # pragma: no cover - defensive
+            raise RuntimeError(f"xAI list voices failed: {last_exc}")
+
+        raw_voices = payload.get("voices", payload if isinstance(payload, list) else [])
+        voices = [self._voice_to_dict(v) for v in raw_voices]
+        self.logger.info("Listed %d xAI voices", len(voices))
+        return voices
+
+    def get_voice(self, voice_id: str) -> Optional[Dict[str, Any]]:
+        """Return metadata for a single voice id, or None if not found."""
+        for voice in self.list_voices():
+            if voice.get("id") == voice_id:
+                return voice
+        return None
+
+    @staticmethod
+    def _voice_to_dict(voice: Dict[str, Any]) -> Dict[str, Any]:
+        """Normalize an xAI voice record (voice_id -> id)."""
+        voice_id = voice.get("voice_id") or voice.get("id")
+        return {
+            "id": voice_id,
+            "name": voice.get("name") or voice_id,
+            "language": voice.get("language"),
+            "gender": voice.get("gender"),
+        }

--- a/artificial_u/integrations/xai/voice_manager.py
+++ b/artificial_u/integrations/xai/voice_manager.py
@@ -1,0 +1,33 @@
+"""
+xAI (Grok) voice catalog.
+
+Non-enterprise xAI accounts cannot clone or create voices and there is no
+public list-voices endpoint, so the catalog is a small, static, curated set of
+the built-in voices. This module is the single source of truth shared by the
+seed script (and any future catalog endpoint).
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+# Built-in xAI voices. Metadata (gender in particular) is curated/best-effort and
+# safe to refine; the UI tolerates a null gender. All voices speak English and
+# can be used for accented-English output regardless of intended language.
+XAI_VOICES: List[Dict[str, Any]] = [
+    {"id": "eve", "name": "Eve", "gender": "female", "language": "en"},
+    {"id": "ara", "name": "Ara", "gender": "female", "language": "en"},
+    {"id": "leo", "name": "Leo", "gender": "male", "language": "en"},
+    {"id": "rex", "name": "Rex", "gender": "male", "language": "en"},
+    {"id": "sal", "name": "Sal", "gender": "male", "language": "en"},
+]
+
+
+class XAIVoiceManager:
+    """Provides the static xAI voice catalog (mirrors the Mistral voice manager API)."""
+
+    def __init__(self, logger: Optional[logging.Logger] = None):
+        self.logger = logger or logging.getLogger(__name__)
+
+    def list_voices(self) -> List[Dict[str, Any]]:
+        """Return the static list of built-in xAI voices."""
+        return [dict(v) for v in XAI_VOICES]

--- a/artificial_u/services/tts_service.py
+++ b/artificial_u/services/tts_service.py
@@ -78,6 +78,7 @@ class TTSService:
         text: str,
         voice_id: str,
         chunk_size: int = 4000,
+        language: Optional[str] = None,
         # Legacy kwargs preserved for backward compatibility
         el_voice_id: Optional[str] = None,
         model_id: Optional[str] = None,
@@ -90,6 +91,8 @@ class TTSService:
             text: Text to convert.
             voice_id: Provider-specific voice identifier.
             chunk_size: Maximum size of text chunks.
+            language: Optional output language (BCP-47). Passed to backends that
+                accept one (e.g. xAI); ignored by others.
             el_voice_id: Legacy alias for voice_id.
             model_id: Optional model override (passed to backend).
             voice_settings: Optional voice settings (passed to backend).
@@ -102,11 +105,10 @@ class TTSService:
         if not effective_voice_id:
             raise ValueError("voice_id is required")
 
-        # Normalize text, skipping SSML if backend doesn't support it
-        if self.backend.supports_ssml():
-            normalized_text = self.speech_processor.normalize_text(text)
-        else:
-            normalized_text = self.speech_processor.normalize_text(text, supports_ssml=False)
+        # Normalize text using the explicit per-backend processing path.
+        normalized_text = self.speech_processor.normalize_text(
+            text, backend_name=self.backend.backend_name
+        )
 
         # Split text into chunks if necessary
         chunks = self.speech_processor.split_into_chunks(normalized_text, max_chunk_size=chunk_size)
@@ -126,6 +128,10 @@ class TTSService:
             backend_kwargs["model_id"] = model_id
         if voice_settings:
             backend_kwargs["voice_settings"] = voice_settings
+        if language:
+            # Backends that don't accept a language kwarg ignore it (they read
+            # only their own keys from **kwargs).
+            backend_kwargs["language"] = language
 
         for i, chunk in enumerate(chunks):
             chunk_len = len(chunk)
@@ -259,6 +265,7 @@ class TTSService:
         voice_id: Optional[str] = None,
         el_voice_id: Optional[str] = None,
         model_id: Optional[str] = None,
+        language: Optional[str] = None,
     ) -> bytes:
         """
         Generate audio for a lecture.
@@ -269,6 +276,8 @@ class TTSService:
             voice_id: Provider-specific voice identifier.
             el_voice_id: Legacy alias for voice_id (ElevenLabs voice ID).
             model_id: Optional model override.
+            language: Optional output language (BCP-47); passed to backends
+                that accept one (e.g. xAI).
 
         Returns:
             Audio data as bytes.
@@ -304,6 +313,7 @@ class TTSService:
                 text=lecture.content,
                 voice_id=effective_voice_id,
                 model_id=model_id,
+                language=language,
             )
         except Exception as e:
             raise AudioProcessingError(f"Failed to generate lecture audio: {e}")

--- a/artificial_u/services/voice_service.py
+++ b/artificial_u/services/voice_service.py
@@ -721,6 +721,20 @@ class VoiceService:
                             voice.language = str(lang_list[0])
                 except Exception as e:
                     self.logger.warning("Could not enrich Mistral voice metadata: %s", e)
+            elif tts_backend == "xai":
+                try:
+                    from artificial_u.integrations.xai.voice_manager import (
+                        XAIVoiceManager,
+                    )
+
+                    info = XAIVoiceManager().get_voice(external_id)
+                    if info:
+                        voice.name = info.get("name") or external_id
+                        voice.gender = info.get("gender")
+                        voice.language = info.get("language")
+                        voice.category = "preset"
+                except Exception as e:
+                    self.logger.warning("Could not enrich xAI voice metadata: %s", e)
 
             voice = self.repository_factory.voice.upsert(voice)
             self.logger.info(

--- a/artificial_u/system.py
+++ b/artificial_u/system.py
@@ -36,6 +36,7 @@ class UniversitySystem:
         anthropic_api_key: Optional[str] = None,
         elevenlabs_api_key: Optional[str] = None,
         mistral_api_key: Optional[str] = None,
+        xai_api_key: Optional[str] = None,
         google_api_key: Optional[str] = None,
         openai_api_key: Optional[str] = None,
         db_url: Optional[str] = None,
@@ -53,6 +54,7 @@ class UniversitySystem:
             anthropic_api_key: API key for Anthropic
             elevenlabs_api_key: API key for ElevenLabs
             mistral_api_key: API key for Mistral (TTS when using Mistral backend)
+            xai_api_key: API key for xAI (TTS when using xAI backend)
             google_api_key: API key for Google
             openai_api_key: API key for OpenAI
             db_url: PostgreSQL database URL
@@ -71,6 +73,7 @@ class UniversitySystem:
             anthropic_api_key,
             elevenlabs_api_key,
             mistral_api_key,
+            xai_api_key,
             google_api_key,
             openai_api_key,
         )
@@ -98,6 +101,7 @@ class UniversitySystem:
         anthropic_api_key: Optional[str],
         elevenlabs_api_key: Optional[str],
         mistral_api_key: Optional[str],
+        xai_api_key: Optional[str],
         google_api_key: Optional[str],
         openai_api_key: Optional[str],
     ):
@@ -108,6 +112,8 @@ class UniversitySystem:
             self.settings.ELEVENLABS_API_KEY = elevenlabs_api_key
         if mistral_api_key:
             self.settings.MISTRAL_API_KEY = mistral_api_key
+        if xai_api_key:
+            self.settings.XAI_API_KEY = xai_api_key
         if google_api_key:
             self.settings.GOOGLE_API_KEY = google_api_key
         if openai_api_key:

--- a/cdk/cdk/cdk_stack.py
+++ b/cdk/cdk/cdk_stack.py
@@ -188,6 +188,11 @@ class CdkStack(Stack):
                     self, "MistralApiKey", "/artificial-u/prod/MISTRAL_API_KEY"
                 )
             ),
+            "XAI_API_KEY": ecs.Secret.from_ssm_parameter(
+                ssm.StringParameter.from_string_parameter_name(
+                    self, "XaiApiKey", "/artificial-u/prod/XAI_API_KEY"
+                )
+            ),
             "GOOGLE_API_KEY": ecs.Secret.from_ssm_parameter(
                 ssm.StringParameter.from_string_parameter_name(
                     self, "GoogleApiKey", "/artificial-u/prod/GOOGLE_API_KEY"

--- a/conftest.py
+++ b/conftest.py
@@ -50,5 +50,7 @@ def verify_test_environment():
         assert settings.OPENAI_API_KEY == "test_openai_key", "Using incorrect OpenAI key"
     if settings.MISTRAL_API_KEY:
         assert settings.MISTRAL_API_KEY == "test_mistral_key", "Using incorrect Mistral key"
+    if settings.XAI_API_KEY:
+        assert settings.XAI_API_KEY == "test_xai_key", "Using incorrect xAI key"
 
     yield

--- a/docs/CDK_STACK_RECOVERY.md
+++ b/docs/CDK_STACK_RECOVERY.md
@@ -135,6 +135,7 @@ Or push to `prod` branch to trigger GitHub Actions workflow.
   - `/artificial-u/prod/ANTHROPIC_API_KEY`
   - `/artificial-u/prod/ELEVENLABS_API_KEY`
   - `/artificial-u/prod/MISTRAL_API_KEY`
+  - `/artificial-u/prod/XAI_API_KEY`
   - `/artificial-u/prod/GOOGLE_API_KEY`
   - `/artificial-u/prod/OPENAI_API_KEY`
   - `/artificial-u/prod/AUTH0_DOMAIN`

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -144,6 +144,7 @@ Create the following SSM Parameters of type `String`:
 - `/artificial-u/prod/ANTHROPIC_API_KEY`
 - `/artificial-u/prod/ELEVENLABS_API_KEY`
 - `/artificial-u/prod/MISTRAL_API_KEY`
+- `/artificial-u/prod/XAI_API_KEY`
 - `/artificial-u/prod/GOOGLE_API_KEY`
 - `/artificial-u/prod/OPENAI_API_KEY`
 - `/artificial-u/prod/AUTH0_DOMAIN`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -267,6 +267,7 @@ TESTING=true
 | `ANTHROPIC_API_KEY` | API key for Anthropic | None | No |
 | `ELEVENLABS_API_KEY` | API key for ElevenLabs | None | No |
 | `MISTRAL_API_KEY` | API key for Mistral (TTS when using Mistral backend) | None | No |
+| `XAI_API_KEY` | API key for xAI (TTS when using xAI/Grok backend) | None | No |
 | `GOOGLE_API_KEY` | API key for Google | None | No |
 | `OPENAI_API_KEY` | API key for OpenAI | None | No |
 | `CONTENT_LOGS_PATH` | (Deprecated) Path for content generation logs | `content_logs` | No |
@@ -288,6 +289,8 @@ TESTING=true
 | `PROFESSOR_GENERATION_MODEL` | Model for professor generation | `gpt-5.4-nano` | No |
 | `IMAGE_GENERATION_MODEL` | Model for image generation | `gemini-3.1-flash-image` | No |
 | `TTS_VOICE_MODEL` | Model for text-to-speech voice | `eleven_flash_v2_5` | No |
+| `XAI_TTS_BASE_URL` | Base URL for the xAI TTS API | `https://api.x.ai/v1` | No |
+| `XAI_TTS_LANGUAGE` | Default output language (BCP-47) for the xAI backend | `en` | No |
 | `LECTURE_WORD_COUNT` | Target word count for generated lectures | `3000` | No |
 | `LECTURE_IMAGE_INTERVAL_SEC` | Approximate seconds between generated lecture images | `45` | No |
 | `STORAGE_TYPE` | Storage type ("minio" or "s3") | `minio` | No |

--- a/scripts/seed_xai_voices.py
+++ b/scripts/seed_xai_voices.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+Seed xAI (Grok) voices into the voices table (idempotent).
+
+xAI offers a small, fixed set of built-in voices and (for non-enterprise
+accounts) no voice cloning/creation and no public list-voices endpoint. We
+therefore seed a curated static catalog. Voices that already exist (matched by
+tts_backend + external_id) are skipped.
+
+The professor voice view lists xAI voices via GET /api/v1/voices?tts_backend=xai,
+so this script must be run once per environment for the xAI tab to populate.
+"""
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(Path(__file__).parent.parent / ".env")
+
+from artificial_u.integrations.xai.voice_manager import XAIVoiceManager  # noqa: E402
+from artificial_u.models.core import Voice  # noqa: E402
+from artificial_u.models.repositories.voice import VoiceRepository  # noqa: E402
+
+TTS_BACKEND = "xai"
+
+
+def seed_xai_voices(
+    db_url: str | None = None,
+    dry_run: bool = False,
+    logger: logging.Logger | None = None,
+) -> tuple[int, int]:
+    """
+    Seed xAI voices from the static catalog. Idempotent.
+
+    Returns:
+        Tuple of (created_count, skipped_count)
+    """
+    if logger is None:
+        logger = logging.getLogger(__name__)
+
+    raw_voices = XAIVoiceManager(logger=logger).list_voices()
+    logger.info("Loaded %d xAI voices from the static catalog", len(raw_voices))
+
+    effective_url = db_url or os.environ.get("DATABASE_URL")
+    repo = VoiceRepository(db_url=effective_url)
+
+    created = 0
+    skipped = 0
+
+    for v in raw_voices:
+        external_id = v.get("id")
+        if not external_id:
+            continue
+
+        existing = repo.get_by_external_id(TTS_BACKEND, external_id)
+        if existing is not None:
+            logger.debug("Voice already exists: %s (db id=%s)", v.get("name"), existing.id)
+            skipped += 1
+            continue
+
+        if dry_run:
+            logger.info("[DRY RUN] Would create: %s (%s)", v.get("name"), external_id)
+            created += 1
+            continue
+
+        voice = Voice(
+            tts_backend=TTS_BACKEND,
+            external_id=external_id,
+            name=v.get("name") or external_id,
+            gender=v.get("gender"),
+            language=v.get("language") or "en",
+            category="preset",
+            description=v.get("description"),
+        )
+
+        repo.create(voice)
+        logger.info("Created voice: %s (external_id=%s)", voice.name, external_id)
+        created += 1
+
+    return created, skipped
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Seed xAI (Grok) voices from the static catalog")
+    parser.add_argument("--db-url", help="Database URL (default: DATABASE_URL env var)")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Report changes without applying them"
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Logging level (default: INFO)",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    logger = logging.getLogger(__name__)
+
+    try:
+        if args.dry_run:
+            logger.info("DRY RUN mode — no changes will be made")
+
+        created, skipped = seed_xai_voices(db_url=args.db_url, dry_run=args.dry_run, logger=logger)
+        logger.info("xAI voice seeding complete: %d created, %d skipped", created, skipped)
+
+    except Exception as e:
+        logger.error("Error seeding xAI voices: %s", e)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/seed_xai_voices.py
+++ b/scripts/seed_xai_voices.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 """
-Seed xAI (Grok) voices into the voices table (idempotent).
+Seed xAI (Grok) voices into the voices table from the live API (idempotent).
 
-xAI offers a small, fixed set of built-in voices and (for non-enterprise
-accounts) no voice cloning/creation and no public list-voices endpoint. We
-therefore seed a curated static catalog. Voices that already exist (matched by
-tts_backend + external_id) are skipped.
+Fetches the actual voice catalog from the xAI Voices API and upserts records
+into the local database. Voices that already exist (matched by tts_backend +
+external_id) are skipped.
 
-The professor voice view lists xAI voices via GET /api/v1/voices?tts_backend=xai,
-so this script must be run once per environment for the xAI tab to populate.
+NOTE: Seeding is optional. The frontend lists xAI voices on-demand via
+GET /api/v1/voices/xai/catalog, so new voices appear automatically without
+running this script. Seeding is useful if you prefer a pre-populated DB.
 """
 
 import argparse
@@ -36,7 +36,7 @@ def seed_xai_voices(
     logger: logging.Logger | None = None,
 ) -> tuple[int, int]:
     """
-    Seed xAI voices from the static catalog. Idempotent.
+    Seed xAI voices from the live API. Idempotent.
 
     Returns:
         Tuple of (created_count, skipped_count)
@@ -44,8 +44,13 @@ def seed_xai_voices(
     if logger is None:
         logger = logging.getLogger(__name__)
 
-    raw_voices = XAIVoiceManager(logger=logger).list_voices()
-    logger.info("Loaded %d xAI voices from the static catalog", len(raw_voices))
+    api_key = os.environ.get("XAI_API_KEY")
+    if not api_key:
+        logger.error("XAI_API_KEY is not set — cannot fetch voice catalog")
+        sys.exit(1)
+
+    raw_voices = XAIVoiceManager(api_key=api_key, logger=logger).list_voices()
+    logger.info("Fetched %d voices from xAI API", len(raw_voices))
 
     effective_url = db_url or os.environ.get("DATABASE_URL")
     repo = VoiceRepository(db_url=effective_url)
@@ -74,9 +79,8 @@ def seed_xai_voices(
             external_id=external_id,
             name=v.get("name") or external_id,
             gender=v.get("gender"),
-            language=v.get("language") or "en",
+            language=v.get("language"),
             category="preset",
-            description=v.get("description"),
         )
 
         repo.create(voice)
@@ -87,7 +91,7 @@ def seed_xai_voices(
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Seed xAI (Grok) voices from the static catalog")
+    parser = argparse.ArgumentParser(description="Seed xAI (Grok) voices from the live API")
     parser.add_argument("--db-url", help="Database URL (default: DATABASE_URL env var)")
     parser.add_argument(
         "--dry-run", action="store_true", help="Report changes without applying them"

--- a/tests/unit/README.md
+++ b/tests/unit/README.md
@@ -25,6 +25,7 @@ Unit tests use dummy API keys from `.env.test`:
 
 - `ELEVENLABS_API_KEY=test_elevenlabs_key`
 - `MISTRAL_API_KEY=test_mistral_key`
+- `XAI_API_KEY=test_xai_key`
 - `ANTHROPIC_API_KEY=test_anthropic_key`
 - `GOOGLE_API_KEY=test_google_key`
 - `OPENAI_API_KEY=test_openai_key`

--- a/tests/unit/audio/test_speech_processor.py
+++ b/tests/unit/audio/test_speech_processor.py
@@ -302,3 +302,115 @@ More content"""
         assert not processor.is_valid_chunk("   ")  # Only whitespace
         assert not processor.is_valid_chunk("No")  # Too short (< 3 words)
         assert not processor.is_valid_chunk("!!!")  # No alphanumeric characters
+
+
+class TestSpeechProcessorMistral:
+    """Per-backend processing for the Mistral (non-markup) path."""
+
+    @pytest.fixture
+    def processor(self):
+        return SpeechProcessor()
+
+    @pytest.mark.unit
+    def test_mistral_strips_pause_directions(self, processor):
+        """Mistral path removes pause brackets entirely, no SSML/markup added."""
+        out = processor.normalize_text(
+            "Please consider this. [Pause] Now continue.", backend_name="mistral"
+        )
+        assert "<break" not in out
+        assert "[Pause]" not in out
+        assert "[pause]" not in out
+        assert "Please consider this." in out and "Now continue." in out
+
+    @pytest.mark.unit
+    def test_mistral_keeps_non_pause_brackets(self, processor):
+        """Non-pause stage directions are left intact for Mistral."""
+        out = processor.normalize_text("He speaks. [walks to the front]", backend_name="mistral")
+        assert "<soft>" not in out
+        assert "[walks to the front" in out
+
+    @pytest.mark.unit
+    def test_unknown_backend_defaults_to_clean_prose(self, processor):
+        """Unknown backends fall back to clean prose (pause directions stripped)."""
+        out = processor.normalize_text(
+            "Please consider this. [Pause] Now continue.", backend_name="totally-new"
+        )
+        assert "<break" not in out and "[pause]" not in out and "[Pause]" not in out
+
+
+class TestSpeechProcessorXai:
+    """Per-backend processing for the xAI (Grok) path."""
+
+    @pytest.fixture
+    def processor(self):
+        return SpeechProcessor()
+
+    @pytest.mark.unit
+    def test_pause_maps_to_pause_tag(self, processor):
+        out = processor.normalize_text(
+            "Please consider this. [Pause] Now continue.", backend_name="xai"
+        )
+        assert "[pause]" in out
+        assert "<break" not in out
+
+    @pytest.mark.unit
+    def test_slight_pause_maps_to_pause_tag(self, processor):
+        out = processor.normalize_text(
+            "This is tricky. [Slight pause] But manageable.", backend_name="xai"
+        )
+        assert "[pause]" in out
+
+    @pytest.mark.unit
+    def test_pause_for_maps_to_long_pause(self, processor):
+        out = processor.normalize_text("Intro. [Pause for emphasis] Outro.", backend_name="xai")
+        assert "[long-pause]" in out
+
+    @pytest.mark.unit
+    def test_duration_pause_maps_to_long_pause(self, processor):
+        out = processor.normalize_text(
+            "She considers. [Pauses for three seconds] Responds.", backend_name="xai"
+        )
+        assert "[long-pause]" in out
+
+    @pytest.mark.unit
+    def test_stage_direction_wrapped_in_soft(self, processor):
+        out = processor.normalize_text(
+            "He speaks. [walks to the front of the classroom]", backend_name="xai"
+        )
+        assert "<soft>walks to the front of the classroom</soft>" in out
+        # No stray period inserted inside the wrap by line normalization.
+        inner = out.split("<soft>")[1].split("</soft>")[0]
+        assert not inner.endswith(".")
+
+    @pytest.mark.unit
+    def test_comma_variant_keeps_remainder_as_soft(self, processor):
+        out = processor.normalize_text(
+            "Now continue. [Slight pause, then resumes] OK.", backend_name="xai"
+        )
+        assert "[pause]" in out
+        assert "<soft>then resumes</soft>" in out
+
+    @pytest.mark.unit
+    def test_pause_tags_not_wrapped_in_soft(self, processor):
+        """Emitted [pause]/[long-pause] tags must never be wrapped in <soft>."""
+        out = processor.normalize_text("A. [Pause] B. [Pause for effect] C.", backend_name="xai")
+        assert "<soft>pause</soft>" not in out
+        assert "<soft>long-pause</soft>" not in out
+
+    @pytest.mark.unit
+    def test_pauses_at_remains_for_xai(self, processor):
+        out = processor.normalize_text(
+            "He turns. [Pauses at the door] Then exits.", backend_name="xai"
+        )
+        # Not a pause tag; treated as a stage direction wrapped in <soft>.
+        assert "<soft>Pauses at the door</soft>" in out
+
+    @pytest.mark.unit
+    def test_chunking_does_not_split_soft_span(self, processor):
+        """A <soft> span produced for xAI should survive chunking intact."""
+        text = processor.normalize_text(
+            "He speaks. [walks slowly to the front of the classroom]", backend_name="xai"
+        )
+        chunks = processor.split_into_chunks(text, max_chunk_size=4000)
+        joined = "".join(chunks)
+        assert "<soft>walks slowly to the front of the classroom</soft>" in joined

--- a/tests/unit/integrations/test_xai_tts.py
+++ b/tests/unit/integrations/test_xai_tts.py
@@ -1,0 +1,124 @@
+"""Unit tests for the xAI (Grok) TTS client, backend adapter, and factory."""
+
+import httpx
+import pytest
+
+from artificial_u.integrations.tts.factory import create_tts_backend
+from artificial_u.integrations.tts.xai_backend import XAITTSBackend
+from artificial_u.integrations.xai.tts_client import XAITTSClient
+
+
+class _FakeResponse:
+    def __init__(self, content=b"audio-bytes", status_code=200):
+        self.content = content
+        self.status_code = status_code
+        self.text = ""
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("error", request=None, response=self)
+
+
+class _FakeClient:
+    """Stand-in for httpx.Client capturing the last POST call."""
+
+    last_call = {}
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def post(self, url, json=None, headers=None):
+        _FakeClient.last_call = {"url": url, "json": json, "headers": headers}
+        return _FakeResponse()
+
+
+@pytest.fixture
+def patch_httpx(monkeypatch):
+    _FakeClient.last_call = {}
+    monkeypatch.setattr("artificial_u.integrations.xai.tts_client.httpx.Client", _FakeClient)
+    return _FakeClient
+
+
+@pytest.mark.unit
+def test_client_posts_to_tts_endpoint_with_bearer(patch_httpx):
+    client = XAITTSClient(api_key="key-123", base_url="https://api.x.ai/v1")
+    audio = client.text_to_speech("Hello world", voice_id="ara", language="en")
+
+    assert audio == b"audio-bytes"  # raw bytes, not JSON
+    call = patch_httpx.last_call
+    assert call["url"] == "https://api.x.ai/v1/tts"
+    assert call["headers"]["Authorization"] == "Bearer key-123"
+    body = call["json"]
+    assert body["text"] == "Hello world"
+    assert body["voice_id"] == "ara"
+    assert body["language"] == "en"
+    assert body["output_format"]["codec"] == "mp3"
+
+
+@pytest.mark.unit
+def test_client_defaults_voice_and_language(patch_httpx):
+    client = XAITTSClient(api_key="key", base_url="https://api.x.ai/v1")
+    client.text_to_speech("Hi there everyone")
+    body = patch_httpx.last_call["json"]
+    assert body["voice_id"] == "eve"
+    assert body["language"] == "en"
+
+
+@pytest.mark.unit
+def test_client_retries_then_raises(monkeypatch):
+    monkeypatch.setattr("artificial_u.integrations.xai.tts_client.time.sleep", lambda *_: None)
+
+    attempts = {"n": 0}
+
+    class _AlwaysFails(_FakeClient):
+        def post(self, url, json=None, headers=None):
+            attempts["n"] += 1
+            raise httpx.ConnectError("boom")
+
+    monkeypatch.setattr("artificial_u.integrations.xai.tts_client.httpx.Client", _AlwaysFails)
+    client = XAITTSClient(api_key="key")
+    with pytest.raises(httpx.ConnectError):
+        client.text_to_speech("text")
+    assert attempts["n"] == XAITTSClient.MAX_RETRIES
+
+
+@pytest.mark.unit
+def test_backend_adapter_uses_client(patch_httpx):
+    client = XAITTSClient(api_key="key", base_url="https://api.x.ai/v1")
+    backend = XAITTSBackend(client=client)
+    assert backend.backend_name == "xai"
+
+    backend.text_to_speech("Some lecture text here", voice_id="leo")
+    body = patch_httpx.last_call["json"]
+    assert body["voice_id"] == "leo"
+
+
+@pytest.mark.unit
+def test_backend_ignores_unrelated_kwargs(patch_httpx):
+    """model_id / voice_settings (used by other backends) must not break xAI."""
+    client = XAITTSClient(api_key="key", base_url="https://api.x.ai/v1")
+    backend = XAITTSBackend(client=client)
+    backend.text_to_speech(
+        "text here please", voice_id="rex", model_id="ignored", voice_settings={"x": 1}
+    )
+    body = patch_httpx.last_call["json"]
+    assert body["voice_id"] == "rex"
+
+
+@pytest.mark.unit
+def test_factory_creates_xai_backend(patch_httpx):
+    backend = create_tts_backend(backend_name="xai", api_key="key")
+    assert isinstance(backend, XAITTSBackend)
+    assert backend.backend_name == "xai"
+
+
+@pytest.mark.unit
+def test_factory_rejects_unknown_backend():
+    with pytest.raises(ValueError):
+        create_tts_backend(backend_name="not-a-backend", api_key="key")

--- a/tests/unit/integrations/test_xai_tts.py
+++ b/tests/unit/integrations/test_xai_tts.py
@@ -122,3 +122,82 @@ def test_factory_creates_xai_backend(patch_httpx):
 def test_factory_rejects_unknown_backend():
     with pytest.raises(ValueError):
         create_tts_backend(backend_name="not-a-backend", api_key="key")
+
+
+# ---------------------------------------------------------------------------
+# Voice manager (live catalog from GET /tts/voices)
+# ---------------------------------------------------------------------------
+
+
+class _FakeVoicesResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class _FakeVoicesClient:
+    """Stand-in for httpx.Client that returns a canned voices payload."""
+
+    payload = {
+        "voices": [
+            {"voice_id": "eve", "name": "Eve", "language": "multilingual"},
+            {"voice_id": "ara", "name": "Ara", "language": "multilingual"},
+            {"voice_id": "camille", "name": "Camille", "language": "fr", "gender": "female"},
+            {"voice_id": "xia", "name": "Xia", "language": "zh", "gender": "female"},
+        ]
+    }
+    last_call = {}
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def get(self, url, headers=None):
+        _FakeVoicesClient.last_call = {"url": url, "headers": headers}
+        return _FakeVoicesResponse(self.payload)
+
+
+@pytest.fixture
+def patch_voices_httpx(monkeypatch):
+    _FakeVoicesClient.last_call = {}
+    monkeypatch.setattr(
+        "artificial_u.integrations.xai.voice_manager.httpx.Client", _FakeVoicesClient
+    )
+    return _FakeVoicesClient
+
+
+@pytest.mark.unit
+def test_voice_manager_lists_all_voices(patch_voices_httpx):
+    from artificial_u.integrations.xai.voice_manager import XAIVoiceManager
+
+    mgr = XAIVoiceManager(api_key="key", base_url="https://api.x.ai/v1")
+    voices = mgr.list_voices()
+
+    assert patch_voices_httpx.last_call["url"] == "https://api.x.ai/v1/tts/voices"
+    assert patch_voices_httpx.last_call["headers"]["Authorization"] == "Bearer key"
+    # voice_id is normalized to id; language-specific voices included
+    ids = {v["id"] for v in voices}
+    assert ids == {"eve", "ara", "camille", "xia"}
+    camille = next(v for v in voices if v["id"] == "camille")
+    assert camille["name"] == "Camille"
+    assert camille["language"] == "fr"
+    assert camille["gender"] == "female"
+
+
+@pytest.mark.unit
+def test_voice_manager_get_voice(patch_voices_httpx):
+    from artificial_u.integrations.xai.voice_manager import XAIVoiceManager
+
+    mgr = XAIVoiceManager(api_key="key", base_url="https://api.x.ai/v1")
+    assert mgr.get_voice("xia")["language"] == "zh"
+    assert mgr.get_voice("nonexistent") is None

--- a/tests/unit/test_api_keys.py
+++ b/tests/unit/test_api_keys.py
@@ -25,6 +25,9 @@ def test_environment_variables_are_set():
         os.environ.get("MISTRAL_API_KEY") == "test_mistral_key"
     ), "Mistral API key not set to test value"
 
+    # Verify xAI API key
+    assert os.environ.get("XAI_API_KEY") == "test_xai_key", "xAI API key not set to test value"
+
     # Verify Google API key
     assert (
         os.environ.get("GOOGLE_API_KEY") == "test_google_key"

--- a/web/src/api/config.ts
+++ b/web/src/api/config.ts
@@ -137,6 +137,7 @@ export const ENDPOINTS = {
       `/v1/voices/by_external/${encodeURIComponent(backend)}/${encodeURIComponent(externalId)}`,
     preview: '/v1/voices/preview',
     mistralCatalog: '/v1/voices/mistral/catalog',
+    xaiCatalog: '/v1/voices/xai/catalog',
     designPreviews: '/v1/voices/design/previews',
     designSave: '/v1/voices/design/save',
     cloneToMistral: '/v1/voices/clone-to-mistral',

--- a/web/src/api/services/voice-service.ts
+++ b/web/src/api/services/voice-service.ts
@@ -14,6 +14,7 @@ import type {
   VoiceListParams,
   VoicePreviewRequest,
   VoicePreviewResponse,
+  XaiVoiceCatalog,
 } from '../types'
 
 /**
@@ -111,6 +112,28 @@ export const listMistralCatalog = async (
   const qs = params.toString()
   const url = qs ? `${ENDPOINTS.voices.mistralCatalog}?${qs}` : ENDPOINTS.voices.mistralCatalog
   return httpClient.get<MistralVoiceCatalog>(url)
+}
+
+/**
+ * List xAI voices on-demand from the xAI API (not stored in DB).
+ *
+ * The catalog is read fresh each time, so newly added xAI voices appear
+ * automatically.
+ *
+ * @param language - Optional language prefix filter (e.g. "fr").
+ * @param gender - Optional gender filter.
+ * @returns Promise<XaiVoiceCatalog>
+ */
+export const listXaiCatalog = async (
+  language?: string,
+  gender?: string
+): Promise<XaiVoiceCatalog> => {
+  const params = new URLSearchParams()
+  if (language) params.set('language', language)
+  if (gender) params.set('gender', gender)
+  const qs = params.toString()
+  const url = qs ? `${ENDPOINTS.voices.xaiCatalog}?${qs}` : ENDPOINTS.voices.xaiCatalog
+  return httpClient.get<XaiVoiceCatalog>(url)
 }
 
 /**

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -544,6 +544,19 @@ export interface MistralVoiceCatalog {
   total: number
 }
 
+// xAI voice catalog (on-demand from xAI API, not stored in DB)
+export interface XaiCatalogVoice {
+  id: string
+  name: string
+  language: string | null
+  gender: string | null
+}
+
+export interface XaiVoiceCatalog {
+  items: XaiCatalogVoice[]
+  total: number
+}
+
 // Voice cloning
 export interface VoiceCloneToMistralRequest {
   professor_id: number

--- a/web/src/components/professors/ProfessorDetail.tsx
+++ b/web/src/components/professors/ProfessorDetail.tsx
@@ -69,6 +69,7 @@ const backendDisplayName = (backend: string): string => {
   const names: Record<string, string> = {
     elevenlabs: 'ElevenLabs',
     mistral: 'Mistral',
+    xai: 'xAI (Grok)',
   }
   return names[backend] ?? backend
 }

--- a/web/src/components/professors/ProfessorVoice.tsx
+++ b/web/src/components/professors/ProfessorVoice.tsx
@@ -14,12 +14,12 @@ import {
   generateVoiceDesignPreviews,
   getVoice,
   listMistralCatalog,
-  listVoices,
+  listXaiCatalog,
   manualAssignVoice,
   previewVoice,
   saveDesignedVoice,
 } from '../../api/services/voice-service.js'
-import type { MistralCatalogVoice, Voice, VoiceDesignPreview } from '../../api/types.js'
+import type { MistralCatalogVoice, VoiceDesignPreview, XaiCatalogVoice } from '../../api/types.js'
 import { RequireRole } from '../../auth/RequireRole'
 import { Alert, Badge, Button, LoadingSpinner } from '../ui'
 
@@ -124,7 +124,7 @@ const VoiceCard: Component<{
 // Voice card for xAI voices (DB-backed Voice records)
 // ---------------------------------------------------------------------------
 const XaiVoiceCard: Component<{
-  voice: Voice
+  voice: XaiCatalogVoice
   isSelected: boolean
   isPreviewing: boolean
   onSelect: () => void
@@ -157,12 +157,7 @@ const XaiVoiceCard: Component<{
     >
       <div class="flex items-start justify-between gap-2">
         <div class="min-w-0 flex-1">
-          <p class="font-semibold text-foreground truncate">
-            {props.voice.name ?? props.voice.external_id}
-          </p>
-          <Show when={props.voice.description}>
-            <p class="text-xs text-muted mt-0.5 truncate">{props.voice.description}</p>
-          </Show>
+          <p class="font-semibold text-foreground truncate">{props.voice.name}</p>
           <div class="flex flex-wrap gap-1.5 mt-1.5">
             <For each={attrs()}>
               {(attr) => (
@@ -256,16 +251,16 @@ const ProfessorVoice: Component = () => {
     return mistralCatalog()?.items.find((v) => v.id === id) ?? null
   })
 
-  // ---- xAI voices (DB-backed; seeded via scripts/seed_xai_voices.py) ----
-  const [xaiVoices] = createResource(
+  // ---- xAI voices (on-demand from the xAI API; read fresh each time) ----
+  const [xaiCatalog] = createResource(
     () => (selectedBackend() === 'xai' ? true : null),
-    async (enabled) => (enabled ? listVoices({ tts_backend: 'xai', limit: 50 }) : undefined)
+    async (enabled) => (enabled ? listXaiCatalog() : undefined)
   )
   const [selectedXaiId, setSelectedXaiId] = createSignal<string | null>(null)
   const selectedXaiVoice = createMemo(() => {
     const id = selectedXaiId()
     if (!id) return null
-    return xaiVoices()?.items.find((v) => v.external_id === id) ?? null
+    return xaiCatalog()?.items.find((v) => v.id === id) ?? null
   })
 
   // ---- Audio preview ----
@@ -288,13 +283,12 @@ const ProfessorVoice: Component = () => {
     }
   }
 
-  const handleXaiPreview = async (voice: Voice) => {
-    if (!voice.external_id) return
-    setIsPreviewingId(voice.external_id)
+  const handleXaiPreview = async (voice: XaiCatalogVoice) => {
+    setIsPreviewingId(voice.id)
     setPreviewAudioUri(null)
     try {
       const resp = await previewVoice({
-        voice_id: voice.external_id,
+        voice_id: voice.id,
         tts_backend: 'xai',
       })
       setPreviewAudioUri(resp.audio_data_uri)
@@ -332,11 +326,11 @@ const ProfessorVoice: Component = () => {
       ttsBackend = 'elevenlabs'
     } else if (backend === 'xai') {
       const voice = selectedXaiVoice()
-      if (!voice?.external_id) {
+      if (!voice) {
         setAssignError('Please select a voice first.')
         return
       }
-      externalId = voice.external_id
+      externalId = voice.id
       ttsBackend = 'xai'
     } else {
       const voice = selectedMistralVoice()
@@ -872,24 +866,23 @@ const ProfessorVoice: Component = () => {
                 </Show>
               </div>
 
-              <Show when={!xaiVoices.loading} fallback={<LoadingSpinner />}>
+              <Show when={!xaiCatalog.loading} fallback={<LoadingSpinner />}>
                 <Show
-                  when={(xaiVoices()?.items.length ?? 0) > 0}
+                  when={(xaiCatalog()?.items.length ?? 0) > 0}
                   fallback={
                     <p class="text-muted text-sm">
-                      No xAI voices found. Run <code>scripts/seed_xai_voices.py</code> to populate
-                      them.
+                      No xAI voices found. Check that XAI_API_KEY is configured.
                     </p>
                   }
                 >
                   <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-                    <For each={xaiVoices()?.items ?? []}>
+                    <For each={xaiCatalog()?.items ?? []}>
                       {(voice) => (
                         <XaiVoiceCard
                           voice={voice}
-                          isSelected={selectedXaiId() === voice.external_id}
-                          isPreviewing={isPreviewingId() === voice.external_id}
-                          onSelect={() => setSelectedXaiId(voice.external_id)}
+                          isSelected={selectedXaiId() === voice.id}
+                          isPreviewing={isPreviewingId() === voice.id}
+                          onSelect={() => setSelectedXaiId(voice.id)}
                           onPreview={() => {
                             void handleXaiPreview(voice)
                           }}

--- a/web/src/components/professors/ProfessorVoice.tsx
+++ b/web/src/components/professors/ProfessorVoice.tsx
@@ -14,20 +14,32 @@ import {
   generateVoiceDesignPreviews,
   getVoice,
   listMistralCatalog,
+  listVoices,
   manualAssignVoice,
   previewVoice,
   saveDesignedVoice,
 } from '../../api/services/voice-service.js'
-import type { MistralCatalogVoice, VoiceDesignPreview } from '../../api/types.js'
+import type { MistralCatalogVoice, Voice, VoiceDesignPreview } from '../../api/types.js'
 import { RequireRole } from '../../auth/RequireRole'
 import { Alert, Badge, Button, LoadingSpinner } from '../ui'
 
-type TtsBackendKey = 'elevenlabs' | 'mistral'
+type TtsBackendKey = 'elevenlabs' | 'mistral' | 'xai'
 
 const BACKEND_OPTIONS: Array<{ value: TtsBackendKey; label: string }> = [
   { value: 'elevenlabs', label: 'ElevenLabs' },
   { value: 'mistral', label: 'Voxtral (Mistral)' },
+  { value: 'xai', label: 'xAI (Grok)' },
 ]
+
+/** Display-friendly name for a TTS backend. */
+const backendLabel = (backend: string | null | undefined): string => {
+  const map: Record<string, string> = {
+    elevenlabs: 'ElevenLabs',
+    mistral: 'Voxtral',
+    xai: 'xAI (Grok)',
+  }
+  return (backend && map[backend]) ?? 'ElevenLabs'
+}
 
 const EXCLUDED_MISTRAL_EMOTIONS = new Set(['sad', 'angry', 'shameful', 'jealousy', 'frustrated'])
 
@@ -109,6 +121,75 @@ const VoiceCard: Component<{
 }
 
 // ---------------------------------------------------------------------------
+// Voice card for xAI voices (DB-backed Voice records)
+// ---------------------------------------------------------------------------
+const XaiVoiceCard: Component<{
+  voice: Voice
+  isSelected: boolean
+  isPreviewing: boolean
+  onSelect: () => void
+  onPreview: () => void
+}> = (props) => {
+  const attrs = createMemo(() => {
+    const v = props.voice
+    const items: Array<{ label: string; value: string }> = []
+    if (v.gender) items.push({ label: 'Gender', value: genderLabel(v.gender) })
+    if (v.language) items.push({ label: 'Lang', value: v.language })
+    return items
+  })
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => {
+        props.onSelect()
+      }}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          props.onSelect()
+        }
+      }}
+      class={`arcane-card-sm p-4 text-left w-full transition-colors cursor-pointer ${
+        props.isSelected ? 'ring-2 ring-accent bg-accent/10' : 'hover:bg-surface-hover'
+      }`}
+    >
+      <div class="flex items-start justify-between gap-2">
+        <div class="min-w-0 flex-1">
+          <p class="font-semibold text-foreground truncate">
+            {props.voice.name ?? props.voice.external_id}
+          </p>
+          <Show when={props.voice.description}>
+            <p class="text-xs text-muted mt-0.5 truncate">{props.voice.description}</p>
+          </Show>
+          <div class="flex flex-wrap gap-1.5 mt-1.5">
+            <For each={attrs()}>
+              {(attr) => (
+                <Badge variant="outline">
+                  <span class="text-muted mr-1">{attr.label}:</span> {attr.value}
+                </Badge>
+              )}
+            </For>
+          </div>
+        </div>
+        <button
+          type="button"
+          class="shrink-0 text-xs px-2 py-1 rounded bg-surface hover:bg-accent/20 text-accent transition-colors"
+          onClick={(e) => {
+            e.stopPropagation()
+            props.onPreview()
+          }}
+          disabled={props.isPreviewing}
+        >
+          {props.isPreviewing ? '...' : '▶ Preview'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
 const ProfessorVoice: Component = () => {
@@ -140,7 +221,12 @@ const ProfessorVoice: Component = () => {
     const voice = currentVoice()
     if (!backendInitialized && voice) {
       backendInitialized = true
-      setSelectedBackend(voice.tts_backend === 'mistral' ? 'mistral' : 'elevenlabs')
+      const backend = voice.tts_backend
+      if (backend === 'mistral' || backend === 'xai') {
+        setSelectedBackend(backend)
+      } else {
+        setSelectedBackend('elevenlabs')
+      }
     }
   })
 
@@ -170,6 +256,18 @@ const ProfessorVoice: Component = () => {
     return mistralCatalog()?.items.find((v) => v.id === id) ?? null
   })
 
+  // ---- xAI voices (DB-backed; seeded via scripts/seed_xai_voices.py) ----
+  const [xaiVoices] = createResource(
+    () => (selectedBackend() === 'xai' ? true : null),
+    async (enabled) => (enabled ? listVoices({ tts_backend: 'xai', limit: 50 }) : undefined)
+  )
+  const [selectedXaiId, setSelectedXaiId] = createSignal<string | null>(null)
+  const selectedXaiVoice = createMemo(() => {
+    const id = selectedXaiId()
+    if (!id) return null
+    return xaiVoices()?.items.find((v) => v.external_id === id) ?? null
+  })
+
   // ---- Audio preview ----
   const [previewAudioUri, setPreviewAudioUri] = createSignal<string | null>(null)
   const [isPreviewingId, setIsPreviewingId] = createSignal<string | null>(null)
@@ -181,6 +279,23 @@ const ProfessorVoice: Component = () => {
       const resp = await previewVoice({
         voice_id: voice.id,
         tts_backend: 'mistral',
+      })
+      setPreviewAudioUri(resp.audio_data_uri)
+    } catch (e) {
+      console.error('Preview failed', e)
+    } finally {
+      setIsPreviewingId(null)
+    }
+  }
+
+  const handleXaiPreview = async (voice: Voice) => {
+    if (!voice.external_id) return
+    setIsPreviewingId(voice.external_id)
+    setPreviewAudioUri(null)
+    try {
+      const resp = await previewVoice({
+        voice_id: voice.external_id,
+        tts_backend: 'xai',
       })
       setPreviewAudioUri(resp.audio_data_uri)
     } catch (e) {
@@ -215,6 +330,14 @@ const ProfessorVoice: Component = () => {
       }
       externalId = id
       ttsBackend = 'elevenlabs'
+    } else if (backend === 'xai') {
+      const voice = selectedXaiVoice()
+      if (!voice?.external_id) {
+        setAssignError('Please select a voice first.')
+        return
+      }
+      externalId = voice.external_id
+      ttsBackend = 'xai'
     } else {
       const voice = selectedMistralVoice()
       if (!voice) {
@@ -362,6 +485,7 @@ const ProfessorVoice: Component = () => {
   const switchBackend = (b: TtsBackendKey) => {
     setSelectedBackend(b)
     setSelectedMistralId(null)
+    setSelectedXaiId(null)
     setPreviewAudioUri(null)
     setAssignError('')
     setAssignSuccess('')
@@ -388,9 +512,7 @@ const ProfessorVoice: Component = () => {
             {(voice) => (
               <>
                 <div class="flex flex-wrap items-center gap-2 text-sm">
-                  <Badge variant="secondary">
-                    {voice().tts_backend === 'elevenlabs' ? 'ElevenLabs' : 'Voxtral'}
-                  </Badge>
+                  <Badge variant="secondary">{backendLabel(voice().tts_backend)}</Badge>
                   <span class="text-foreground font-medium">
                     {voice().name ?? voice().external_id ?? voice().el_voice_id}
                   </span>
@@ -697,6 +819,79 @@ const ProfessorVoice: Component = () => {
                           onSelect={() => setSelectedMistralId(voice.id)}
                           onPreview={() => {
                             void handlePreview(voice)
+                          }}
+                        />
+                      )}
+                    </For>
+                  </div>
+                </Show>
+              </Show>
+
+              {/* Audio player for preview */}
+              <Show when={previewAudioUri()}>
+                <div class="mt-4 p-3 bg-surface rounded-lg">
+                  <p class="text-xs text-muted mb-2">Voice Preview</p>
+                  <audio
+                    controls
+                    autoplay
+                    class="w-full max-w-md"
+                    src={previewAudioUri() ?? ''}
+                    aria-label="Voice preview audio"
+                  >
+                    <track
+                      kind="captions"
+                      src="data:text/vtt;charset=utf-8,WEBVTT%0A%0A"
+                      srclang="en"
+                      label="English captions"
+                      default
+                    />
+                    Your browser does not support the audio element.
+                  </audio>
+                </div>
+              </Show>
+            </div>
+          </Show>
+
+          {/* xAI: voice browsing grid (DB-backed; seeded voices) */}
+          <Show when={selectedBackend() === 'xai'}>
+            <div class="space-y-4">
+              <div class="flex items-center justify-between">
+                <p class="text-sm text-muted">
+                  Browse xAI (Grok) voices and preview them before assigning.
+                </p>
+                <Show when={selectedXaiVoice()}>
+                  <Button
+                    variant="primary"
+                    onClick={() => void handleAssign()}
+                    disabled={isAssigning()}
+                  >
+                    {isAssigning()
+                      ? 'Assigning...'
+                      : `Assign "${selectedXaiVoice()?.name ?? 'voice'}"`}
+                  </Button>
+                </Show>
+              </div>
+
+              <Show when={!xaiVoices.loading} fallback={<LoadingSpinner />}>
+                <Show
+                  when={(xaiVoices()?.items.length ?? 0) > 0}
+                  fallback={
+                    <p class="text-muted text-sm">
+                      No xAI voices found. Run <code>scripts/seed_xai_voices.py</code> to populate
+                      them.
+                    </p>
+                  }
+                >
+                  <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                    <For each={xaiVoices()?.items ?? []}>
+                      {(voice) => (
+                        <XaiVoiceCard
+                          voice={voice}
+                          isSelected={selectedXaiId() === voice.external_id}
+                          isPreviewing={isPreviewingId() === voice.external_id}
+                          onSelect={() => setSelectedXaiId(voice.external_id)}
+                          onPreview={() => {
+                            void handleXaiPreview(voice)
                           }}
                         />
                       )}


### PR DESCRIPTION
Introduce xAI Grok text-to-speech alongside ElevenLabs and Mistral/Voxtral, so a professor's voice can be explored and switched to xAI from the professor voice view (new third tab).

## Backend integration
- `XAITTSClient` (httpx) posting to the xAI `/v1/tts` endpoint, returning raw audio bytes, with retry/backoff and test-env dummy-key handling.
- `XAITTSBackend` adapter + a `"xai"` branch in the TTS factory. Per-professor backend selection already dispatches via the factory, so xAI works end-to-end with no changes to the audio-generation path.
- Config: `XAI_API_KEY`, `XAI_TTS_BASE_URL`, `XAI_TTS_LANGUAGE` (default `"en"`).
- Thread an optional output-`language` kwarg through `TTSService` to backends that accept one (xAI); ElevenLabs/Mistral safely ignore it.

## Text preprocessing
- Replace the SSML/non-SSML bifurcation with explicit **per-backend dispatch** in `SpeechProcessor` (`normalize_text(text, backend_name)`): shared common normalization, then `elevenlabs` (`<break>` tags), `mistral` (strip pauses), or `xai`. ElevenLabs output is byte-identical to before.
- xAI path maps pause stage-directions to `[pause]` / `[long-pause]` and wraps remaining bracketed stage directions (e.g. `[walks to the front]`) in `<soft>…</soft>`.
- Remove the now-unused `supports_ssml` hook from the backend protocol.

## Voices (dynamic, full catalog)
xAI's library is more than the 5 multilingual voices (ara/eve/leo/rex/sal) — it includes language-specific voices across ~20 languages and is expected to grow. Rather than hardcode, we read the catalog live:
- `XAIVoiceManager` queries `GET /v1/tts/voices` (httpx + retry), normalizing `id`/`name`/`language`/`gender`.
- New `GET /v1/voices/xai/catalog` endpoint (mirrors `/mistral/catalog`), with optional `language`/`gender` filters. Read fresh each time, so new voices appear automatically.
- `manual_voice_assignment_generic` enriches xAI voice metadata on assign, persisting a single row on demand (same as Mistral).
- `scripts/seed_xai_voices.py` pulls from the live API (idempotent) — optional, since the UI reads the catalog directly.

## Frontend
- New "xAI (Grok)" tab in `ProfessorVoice`, mirroring the Voxtral browse-grid-with-preview UX, sourcing voices from the live `/xai/catalog` (each card shows language + gender, so a language-X voice can be used for accented English).

## Config / runtime / CDK / CI
- `XAI_API_KEY` given the same first-class treatment as the other external API keys: `.env.example` / `.env.test`, `settings.to_dict()`, `UniversitySystem` + CLI plumbing, `__main__` optional-key warning, CDK ECS secret from SSM `/artificial-u/prod/XAI_API_KEY`, CI test envs, and docs.

## Tests
- Per-backend `SpeechProcessor` cases (mistral/xai/unknown).
- xAI client/adapter/factory unit tests + `XAIVoiceManager.list_voices`/`get_voice` (mocked httpx).
- `XAI_API_KEY` assertions in `conftest.py` and `test_api_keys.py`.

All Python (black/isort/flake8 + unit tests) and frontend (eslint/biome/stylelint/build) checks pass.

https://claude.ai/code/session_012eWCJ6DUCrg83RgK9mo3B5