### PR TITLE
Improve admin jobs page; centralize job priorities; fix batch/SSE bugs

### DIFF
--- a/artificial_u/api/routers/jobs.py
+++ b/artificial_u/api/routers/jobs.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -9,6 +10,7 @@ from pydantic import BaseModel
 from artificial_u.api.dependencies import get_repository_factory
 from artificial_u.api.events import JobEventHub, sse_stream
 from artificial_u.api.security.auth0 import require_auth
+from artificial_u.config import get_settings
 from artificial_u.models.repositories.factory import RepositoryFactory
 
 router = APIRouter(prefix="/jobs", tags=["jobs"])
@@ -29,7 +31,106 @@ def _duration_ms_from_result(result: Any) -> Any:
         return None
 
 
-def _job_row_response(r) -> dict:
+def _tts_model_name(settings) -> Optional[str]:
+    """Best-effort TTS model name for the configured backend."""
+    backend = (settings.tts_backend or "").lower()
+    if backend == "mistral":
+        return settings.TTS_MISTRAL_MODEL
+    if backend == "xai":
+        # xAI's TTS endpoint does not expose a tunable model name; show the backend.
+        return "xai"
+    return settings.TTS_VOICE_MODEL
+
+
+def _job_model_name(kind: str, payload: Any) -> Optional[str]:
+    """
+    Best-effort model name for a job, based on its kind and the global generation
+    settings. Returns None for jobs without a single obvious model (e.g. course
+    creation, exports). Payload-level overrides take precedence where present.
+
+    Note: this reflects the global defaults; per-professor / per-voice overrides
+    applied at runtime are not resolved here.
+    """
+    payload = payload if isinstance(payload, dict) else {}
+    override = payload.get("model_name_override")
+    if override:
+        return str(override)
+
+    settings = get_settings()
+    if kind == "generate_lecture_audio":
+        return _tts_model_name(settings)
+
+    mapping = {
+        "generate_course": settings.COURSE_GENERATION_MODEL,
+        "generate_department": settings.DEPARTMENT_GENERATION_MODEL,
+        "generate_professor": settings.PROFESSOR_GENERATION_MODEL,
+        "generate_topics_for_course": settings.TOPICS_GENERATION_MODEL,
+        "generate_lecture": settings.LECTURE_GENERATION_MODEL,
+        "generate_lecture_text_only": settings.LECTURE_GENERATION_MODEL,
+        "generate_lecture_summary": settings.LECTURE_SUMMARY_MODEL,
+        "generate_lecture_images": settings.IMAGE_GENERATION_MODEL,
+        "resume_lecture_images": settings.IMAGE_GENERATION_MODEL,
+        "generate_lecture_slide": settings.IMAGE_GENERATION_MODEL,
+        "remap_lecture_images_timeline": settings.IMAGE_GENERATION_MODEL,
+        "generate_professor_image": settings.IMAGE_GENERATION_MODEL,
+        "generate_course_image": settings.IMAGE_GENERATION_MODEL,
+    }
+    return mapping.get(kind)
+
+
+def _coerce_int(value: Any) -> Optional[int]:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.strip().lstrip("-").isdigit():
+        return int(value)
+    return None
+
+
+def _job_link_path(payload: Any, result: Any, factory=None) -> Optional[str]:
+    """
+    Resolve a relative frontend path to the lecture or topic a job concerns.
+
+    Prefers the lecture when both a lecture and topic are present. The lecture /
+    topic detail routes are nested under a course, so a course id is required; it
+    is taken from the payload/result when available and otherwise resolved via a
+    single primary-key lookup.
+    """
+    payload = payload if isinstance(payload, dict) else {}
+    result = result if isinstance(result, dict) else {}
+    partial = payload.get("partial_attributes") if isinstance(payload, dict) else {}
+    partial = partial if isinstance(partial, dict) else {}
+
+    def _pick(key: str) -> Optional[int]:
+        for source in (payload, partial, result):
+            val = _coerce_int(source.get(key))
+            if val is not None:
+                return val
+        return None
+
+    lecture_id = _pick("lecture_id")
+    topic_id = _pick("topic_id")
+    course_id = _pick("course_id")
+
+    if lecture_id is not None:
+        if course_id is None and factory is not None:
+            lecture = factory.lecture.get(lecture_id)
+            course_id = getattr(lecture, "course_id", None)
+        if course_id is not None:
+            return f"/courses/{course_id}/lectures/{lecture_id}"
+
+    if topic_id is not None:
+        if course_id is None and factory is not None:
+            topic = factory.topic.get(topic_id)
+            course_id = getattr(topic, "course_id", None)
+        if course_id is not None:
+            return f"/courses/{course_id}/topics/{topic_id}"
+
+    return None
+
+
+def _job_row_response(r, factory=None) -> dict:
     return {
         "id": r.id,
         "kind": r.kind,
@@ -45,17 +146,20 @@ def _job_row_response(r) -> dict:
         "result": r.result,
         "duration_ms": _duration_ms_from_result(r.result),
         "parent_job_id": getattr(r, "parent_job_id", None),
+        "model": _job_model_name(r.kind, r.payload),
+        "link_path": _job_link_path(r.payload, r.result, factory),
     }
 
 
 def _active_job_snapshot(
-    repo,
+    factory,
     *,
     lecture_id: Optional[int],
     topic_id: Optional[int],
     kinds: list[str],
     limit_per_status: int = 100,
 ) -> list[dict]:
+    repo = factory.job
     kinds_set = set(kinds)
     rows = []
     for status in ("queued", "running"):
@@ -70,52 +174,56 @@ def _active_job_snapshot(
     if kinds_set:
         rows = [row for row in rows if row.kind in kinds_set]
     rows.sort(key=lambda row: row.created_at, reverse=True)
-    return [_job_row_response(row) for row in rows]
+    return [_job_row_response(row, factory) for row in rows]
 
 
 class EnqueueJob(BaseModel):
     kind: str
     payload: Dict[str, Any]
-    priority: int = 0
+    # When omitted, the priority is derived from the job kind (see job_priorities).
+    priority: Optional[int] = None
     max_attempts: int = 2
 
 
+async def _publish_job_event(request: Request, event: Dict[str, Any]) -> None:
+    """Best-effort publish of a job event to the SSE hub.
+
+    Reads the hub from app state (the same place ``jobs_stream`` uses) and awaits
+    the publish on the running event loop. Never raises: SSE delivery is
+    non-critical and must not fail the request.
+    """
+    hub: Optional[JobEventHub] = getattr(request.app.state, "job_events", None)
+    if hub is None:
+        return
+    try:
+        await hub.publish(event)
+    except Exception:  # noqa: BLE001
+        logging.getLogger(__name__).debug("Failed to publish job event", exc_info=True)
+
+
 @router.post("", dependencies=[Depends(require_auth)])
-def enqueue(
+async def enqueue(
     job: EnqueueJob,
+    request: Request,
     repository_factory: RepositoryFactory = Depends(get_repository_factory),
 ):
     repo = repository_factory.job
-    row = repo.create(
+    row = await asyncio.to_thread(
+        repo.create,
         kind=job.kind,
         payload=job.payload,
         priority=job.priority,
         max_attempts=job.max_attempts,
     )
-    # Publish queued event to SSE hub (best-effort)
-    try:
-        # Attempt to access global app instance for event hub
-        # FastAPI doesn't inject app here, so we import the app and use its state
-        from artificial_u.api.app import app  # type: ignore
-
-        hub = getattr(app.state, "job_events", None)
-        if hub is not None:
-            # Publish synchronously; hub.publish is async, schedule and forget
-            import asyncio
-
-            asyncio.create_task(
-                hub.publish(
-                    {
-                        "id": row.id,
-                        "kind": row.kind,
-                        "status": "queued",
-                        "payload": row.payload,
-                    }
-                )
-            )
-    except Exception:
-        # Never fail the enqueue API due to SSE publish errors
-        pass
+    await _publish_job_event(
+        request,
+        {
+            "id": row.id,
+            "kind": row.kind,
+            "status": "queued",
+            "payload": row.payload,
+        },
+    )
 
     return {
         "id": row.id,
@@ -149,7 +257,7 @@ def list_jobs(
         course_id=course_id,
         parent_id=parent_id,
     )
-    return [_job_row_response(r) for r in rows]
+    return [_job_row_response(r, repository_factory) for r in rows]
 
 
 @router.get("/summary", dependencies=[Depends(require_auth)])
@@ -195,7 +303,7 @@ async def jobs_stream(
     hub: JobEventHub = request.app.state.job_events
     snapshot = await asyncio.to_thread(
         _active_job_snapshot,
-        repository_factory.job,
+        repository_factory,
         lecture_id=lecture_id,
         topic_id=topic_id,
         kinds=kinds_list,
@@ -230,7 +338,7 @@ def get_job(
     row = repo.get(job_id)
     if not row:
         raise HTTPException(404, "job not found")
-    return _job_row_response(row)
+    return _job_row_response(row, repository_factory)
 
 
 @router.get("/{job_id}/children", dependencies=[Depends(require_auth)])
@@ -242,43 +350,33 @@ def get_job_children(
     if not repo.get(job_id):
         raise HTTPException(404, "job not found")
     rows = repo.list(parent_id=job_id, limit=200)
-    return [_job_row_response(r) for r in rows]
+    return [_job_row_response(r, repository_factory) for r in rows]
 
 
 @router.post("/{job_id}/cancel", dependencies=[Depends(require_auth)])
-def cancel_job(
+async def cancel_job(
     job_id: int,
+    request: Request,
     repository_factory: RepositoryFactory = Depends(get_repository_factory),
 ):
     repo = repository_factory.job
-    row = repo.get(job_id)
+    row = await asyncio.to_thread(repo.get, job_id)
     if not row:
         raise HTTPException(404, "job not found")
     if row.status in ("done", "failed", "cancelled"):
         return {"id": row.id, "status": row.status}
 
     # Set status to cancelled
-    repo.mark_cancelled(job_id)
+    await asyncio.to_thread(repo.mark_cancelled, job_id)
 
-    # Publish cancelled event
-    try:
-        from artificial_u.api.app import app  # type: ignore
-
-        hub = getattr(app.state, "job_events", None)
-        if hub is not None:
-            import asyncio
-
-            asyncio.create_task(
-                hub.publish(
-                    {
-                        "id": job_id,
-                        "kind": row.kind,
-                        "status": "cancelled",
-                        "payload": row.payload or {},
-                    }
-                )
-            )
-    except Exception:
-        pass
+    await _publish_job_event(
+        request,
+        {
+            "id": job_id,
+            "kind": row.kind,
+            "status": "cancelled",
+            "payload": row.payload or {},
+        },
+    )
 
     return {"id": job_id, "status": "cancelled"}

--- a/artificial_u/api/routers/topics.py
+++ b/artificial_u/api/routers/topics.py
@@ -352,7 +352,6 @@ def generate_remaining_lectures(
     row = repository_factory.job.create(
         kind="generate_lecture",
         payload=payload,
-        priority=1,
     )
 
     return {
@@ -424,7 +423,6 @@ def regenerate_remaining_audio(
     row = repository_factory.job.create(
         kind="generate_lecture_audio",
         payload=payload,
-        priority=1,
     )
 
     return {
@@ -495,7 +493,6 @@ def generate_remaining_timelines(
     row = repository_factory.job.create(
         kind="generate_lecture_timeline",
         payload=payload,
-        priority=1,
     )
 
     return {
@@ -564,7 +561,6 @@ def regenerate_remaining_lectures(
     row = repository_factory.job.create(
         kind="generate_lecture",
         payload=payload,
-        priority=1,
     )
 
     return {

--- a/artificial_u/api/worker.py
+++ b/artificial_u/api/worker.py
@@ -500,9 +500,7 @@ class Worker:
             return
 
         # Enqueue the next job
-        await self._enqueue_follow_up_job(
-            action, next_payload, next_topic_id, payload.get("priority", 0)
-        )
+        await self._enqueue_follow_up_job(action, next_payload, next_topic_id)
 
     async def _build_follow_up_payload(
         self,
@@ -566,6 +564,33 @@ class Worker:
             self.logger.error("Follow-up audio generation missing course_id")
             return None
 
+        # Query for the lecture with this topic_id
+        try:
+            lecture_repo = self.repository_factory.lecture
+            lectures = await asyncio.to_thread(lecture_repo.list_by_topic, next_topic_id)
+            if not lectures or len(lectures) == 0:
+                self.logger.warning(
+                    f"No lecture found for topic {next_topic_id}, skipping audio generation"
+                )
+                # Return None to let caller handle continuation with remaining topics
+                return None
+
+            payload: Dict[str, Any] = {
+                "lecture_id": lectures[0].id,
+                "topic_id": next_topic_id,
+            }
+
+            if new_remaining:
+                payload["follow_up"] = {
+                    **follow_up,
+                    "remaining_topic_ids": new_remaining,
+                }
+
+            return payload
+        except Exception as e:
+            self.logger.error(f"Error querying lecture for topic {next_topic_id}: {e}")
+            return None
+
     async def _build_timeline_payload(
         self,
         next_topic_id: int,
@@ -611,48 +636,23 @@ class Worker:
             self.logger.error(f"Error querying lecture for topic {next_topic_id}: {e}")
             return None
 
-        # Query for the lecture with this topic_id
-        try:
-            lecture_repo = self.repository_factory.lecture
-            lectures = await asyncio.to_thread(lecture_repo.list_by_topic, next_topic_id)
-            if not lectures or len(lectures) == 0:
-                self.logger.warning(
-                    f"No lecture found for topic {next_topic_id}, skipping audio generation"
-                )
-                # Return None to let caller handle continuation with remaining topics
-                return None
-
-            payload = {
-                "lecture_id": lectures[0].id,
-                "topic_id": next_topic_id,
-            }
-
-            if new_remaining:
-                payload["follow_up"] = {
-                    **follow_up,
-                    "remaining_topic_ids": new_remaining,
-                }
-
-            return payload
-        except Exception as e:
-            self.logger.error(f"Error querying lecture for topic {next_topic_id}: {e}")
-            return None
-
     async def _enqueue_follow_up_job(
         self,
         action: str,
         next_payload: Dict[str, Any],
         next_topic_id: int,
-        priority: int,
     ) -> None:
-        """Enqueue the follow-up job."""
+        """Enqueue the follow-up job.
+
+        Priority is derived from the job kind (see ``job_priorities``), so it
+        stays consistent across the whole follow-up chain.
+        """
         try:
             repo = self.repository_factory.job
             next_job = await asyncio.to_thread(
                 repo.create,
                 kind=action,
                 payload=next_payload,
-                priority=priority,
             )
             self.logger.info(
                 f"Enqueued follow-up job {next_job.id}: {action} for topic {next_topic_id}"
@@ -683,5 +683,5 @@ class Worker:
                 await self._enqueue_next_in_chain(action, new_remaining, follow_up)
             return
 
-        # Enqueue the job (using default priority of 0)
-        await self._enqueue_follow_up_job(action, next_payload, next_topic_id, 0)
+        # Enqueue the job (priority is derived from the job kind)
+        await self._enqueue_follow_up_job(action, next_payload, next_topic_id)

--- a/artificial_u/models/job_priorities.py
+++ b/artificial_u/models/job_priorities.py
@@ -1,0 +1,40 @@
+"""
+Centralized job scheduling priorities.
+
+Jobs are reserved in ``priority DESC, id ASC`` order (see
+``JobRepository.reserve_one_skip_locked_atomic``), so a *higher* number is
+scheduled sooner and ties fall back to FIFO by id.
+
+Priority is derived from the job *kind* rather than passed around per call. This
+keeps the scheme defined in one place and—critically—keeps it consistent across
+follow-up chains: a chained ``generate_lecture_audio`` job is scheduled with the
+same priority whether it was enqueued directly or as the tail of a batch.
+
+Design intent
+-------------
+The worker pool is small (``WORKER_MAX_CONCURRENCY``), so a few slow,
+rate-limited jobs can starve the many quick jobs behind them. We therefore keep
+most work at the neutral default and *demote* the slow, long-running steps so
+fast jobs (e.g. image slides) are not blocked behind them.
+"""
+
+# Neutral baseline. Most kinds run here, ordered FIFO by id.
+DEFAULT_JOB_PRIORITY = 0
+
+# Negative = run after the neutral default; positive = run before it.
+_JOB_PRIORITIES: dict[str, int] = {
+    # Audio is the slowest and most rate-limited step (TTS). Let everything else
+    # go first so a long audio job doesn't block batches of quick image jobs.
+    "generate_lecture_audio": -20,
+    # Forced-alignment timelines are also slow and depend on audio; keep them
+    # below the neutral default but above audio.
+    "generate_lecture_timeline": -10,
+}
+
+
+def priority_for_kind(kind: str) -> int:
+    """Return the scheduling priority for a job ``kind``.
+
+    Unknown / unlisted kinds fall back to the neutral default.
+    """
+    return _JOB_PRIORITIES.get(kind, DEFAULT_JOB_PRIORITY)

--- a/artificial_u/models/repositories/job.py
+++ b/artificial_u/models/repositories/job.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from sqlalchemy import and_, asc, desc, func, select, text, update
 
 from artificial_u.models.database import JobModel
+from artificial_u.models.job_priorities import priority_for_kind
 from artificial_u.models.repositories.base import BaseRepository
 
 
@@ -21,11 +22,15 @@ class JobRepository(BaseRepository):
         *,
         kind: str,
         payload: Dict[str, Any],
-        priority: int = 0,
+        priority: Optional[int] = None,
         run_after: Optional[dt.datetime] = None,
         max_attempts: int = 2,
         parent_job_id: Optional[int] = None,
     ) -> JobModel:
+        # When no explicit priority is given, derive it from the job kind so the
+        # scheme stays centralized and consistent across follow-up chains.
+        if priority is None:
+            priority = priority_for_kind(kind)
         run_after = run_after or self._now()
         with self.get_session() as session:
             job = JobModel(

--- a/artificial_u/services/job_service.py
+++ b/artificial_u/services/job_service.py
@@ -85,7 +85,6 @@ class JobService:
         self,
         slide_payloads: list[Dict[str, Any]],
         *,
-        slide_priority: int,
         chain_parent_job_id: Optional[int] = None,
     ) -> Optional[Dict[str, Any]]:
         """
@@ -95,7 +94,6 @@ class JobService:
         next_payload: Optional[Dict[str, Any]] = None
         for slide_payload in reversed(slide_payloads):
             current = dict(slide_payload)
-            current["slide_priority"] = slide_priority
             if chain_parent_job_id is not None:
                 current["chain_parent_job_id"] = chain_parent_job_id
             if next_payload is not None:
@@ -125,9 +123,6 @@ class JobService:
         row = self.repository_factory.job.create(
             kind="generate_lecture_slide",
             payload=next_slide_payload,
-            priority=int(
-                next_slide_payload.get("slide_priority", payload.get("slide_priority", -10))
-            ),
             parent_job_id=chain_parent_job_id,
         )
         return row.id
@@ -307,7 +302,6 @@ class JobService:
                 self.repository_factory.job.create(
                     kind="generate_lecture_summary",
                     payload=summary_payload,
-                    priority=payload.get("priority", 0),
                     parent_job_id=parent_job_id,
                 )
             except Exception as e:  # noqa: BLE001
@@ -324,7 +318,6 @@ class JobService:
                 self.repository_factory.job.create(
                     kind="generate_lecture_audio",
                     payload={"lecture_id": saved_lecture.id, "topic_id": saved_lecture.topic_id},
-                    priority=payload.get("priority", 0),
                     parent_job_id=parent_job_id,
                 )
             except Exception as e:  # noqa: BLE001
@@ -408,7 +401,6 @@ class JobService:
                     "lecture_id": lecture_id,
                     "topic_id": payload.get("topic_id") or getattr(lecture, "topic_id", None),
                 },
-                priority=int(payload.get("priority", 0)),
                 parent_job_id=parent_job_id,
             )
             result["remap_images_timeline_job_id"] = row.id
@@ -451,10 +443,8 @@ class JobService:
         if cleanup_result is not None:
             result["deleted_existing_images"] = cleanup_result.get("deleted", 0)
         slide_payloads = result.pop("slide_payloads", [])
-        slide_priority = int(payload.get("slide_priority", -10))
         first_slide_payload = self._build_lecture_slide_chain(
             slide_payloads,
-            slide_priority=slide_priority,
             chain_parent_job_id=parent_job_id,
         )
         job_ids = []
@@ -462,7 +452,6 @@ class JobService:
             row = self.repository_factory.job.create(
                 kind="generate_lecture_slide",
                 payload=first_slide_payload,
-                priority=slide_priority,
                 parent_job_id=parent_job_id,
             )
             job_ids.append(row.id)
@@ -486,10 +475,8 @@ class JobService:
             model_name_override=payload.get("model_name_override"),
         )
         slide_payloads = result.pop("slide_payloads", [])
-        slide_priority = int(payload.get("slide_priority", -10))
         first_slide_payload = self._build_lecture_slide_chain(
             slide_payloads,
-            slide_priority=slide_priority,
             chain_parent_job_id=parent_job_id,
         )
         job_ids = []
@@ -497,7 +484,6 @@ class JobService:
             row = self.repository_factory.job.create(
                 kind="generate_lecture_slide",
                 payload=first_slide_payload,
-                priority=slide_priority,
                 parent_job_id=parent_job_id,
             )
             job_ids.append(row.id)

--- a/tests/unit/api/test_worker_follow_up.py
+++ b/tests/unit/api/test_worker_follow_up.py
@@ -1,0 +1,84 @@
+"""Unit tests for the worker's follow-up payload builders (batch chaining)."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from artificial_u.api.worker import Worker
+
+
+class FakeLectureRepository:
+    def __init__(self, lectures_by_topic):
+        self._lectures_by_topic = lectures_by_topic
+
+    def list_by_topic(self, topic_id):
+        return self._lectures_by_topic.get(topic_id, [])
+
+
+class FakeRepositoryFactory:
+    def __init__(self, lectures_by_topic):
+        self.lecture = FakeLectureRepository(lectures_by_topic)
+
+
+def _make_worker(lectures_by_topic):
+    return Worker(FakeRepositoryFactory(lectures_by_topic))
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_audio_payload_resolves_lecture_and_chains_remaining():
+    worker = _make_worker({7: [SimpleNamespace(id=42)]})
+
+    payload = await worker._build_audio_payload(
+        next_topic_id=7,
+        follow_up={"action": "generate_lecture_audio", "course_id": 3},
+        new_remaining=[8, 9],
+    )
+
+    assert payload is not None
+    assert payload["lecture_id"] == 42
+    assert payload["topic_id"] == 7
+    # The remaining topics are carried forward so the chain continues.
+    assert payload["follow_up"]["remaining_topic_ids"] == [8, 9]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_audio_payload_no_follow_up_when_chain_complete():
+    worker = _make_worker({7: [SimpleNamespace(id=42)]})
+
+    payload = await worker._build_audio_payload(
+        next_topic_id=7,
+        follow_up={"action": "generate_lecture_audio", "course_id": 3},
+        new_remaining=[],
+    )
+
+    assert payload == {"lecture_id": 42, "topic_id": 7}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_audio_payload_returns_none_without_course_id():
+    worker = _make_worker({7: [SimpleNamespace(id=42)]})
+
+    payload = await worker._build_audio_payload(
+        next_topic_id=7,
+        follow_up={"action": "generate_lecture_audio"},
+        new_remaining=[8],
+    )
+
+    assert payload is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_audio_payload_returns_none_when_no_lecture_for_topic():
+    worker = _make_worker({})
+
+    payload = await worker._build_audio_payload(
+        next_topic_id=7,
+        follow_up={"action": "generate_lecture_audio", "course_id": 3},
+        new_remaining=[8],
+    )
+
+    assert payload is None

--- a/tests/unit/models/test_job_priorities.py
+++ b/tests/unit/models/test_job_priorities.py
@@ -1,0 +1,38 @@
+"""Unit tests for the centralized job scheduling priorities."""
+
+import pytest
+
+from artificial_u.models.job_priorities import (
+    DEFAULT_JOB_PRIORITY,
+    priority_for_kind,
+)
+
+
+@pytest.mark.unit
+def test_unknown_kind_falls_back_to_default():
+    assert priority_for_kind("not_a_real_kind") == DEFAULT_JOB_PRIORITY
+
+
+@pytest.mark.unit
+def test_neutral_kinds_use_default():
+    # Image work and lecture text generation stay at the neutral default so they
+    # are not starved behind slow background work.
+    for kind in (
+        "generate_lecture",
+        "generate_lecture_text_only",
+        "generate_lecture_images",
+        "generate_lecture_slide",
+        "generate_topics_for_course",
+    ):
+        assert priority_for_kind(kind) == DEFAULT_JOB_PRIORITY
+
+
+@pytest.mark.unit
+def test_slow_background_work_is_demoted_below_default():
+    # Audio is the slowest, most rate-limited step and must run after fast jobs.
+    audio = priority_for_kind("generate_lecture_audio")
+    timeline = priority_for_kind("generate_lecture_timeline")
+    assert audio < DEFAULT_JOB_PRIORITY
+    assert timeline < DEFAULT_JOB_PRIORITY
+    # Audio is the lowest priority of all.
+    assert audio < timeline

--- a/tests/unit/services/test_job_service.py
+++ b/tests/unit/services/test_job_service.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from artificial_u.models.job_priorities import priority_for_kind
 from artificial_u.services.job_service import JobService
 
 
@@ -15,11 +16,14 @@ class FakeJobRepository:
         *,
         kind,
         payload,
-        priority=0,
+        priority=None,
         run_after=None,
         max_attempts=2,
         parent_job_id=None,
     ):
+        # Mirror the real repository: derive priority from the kind when unset.
+        if priority is None:
+            priority = priority_for_kind(kind)
         row = SimpleNamespace(id=len(self.created) + 1)
         self.created.append(
             {
@@ -71,9 +75,7 @@ async def test_generate_lecture_images_enqueues_only_first_chained_slide():
     )
     service._lecture_images_generator_service_instance = MagicMock(return_value=images_service)
 
-    result = await service._handle_generate_lecture_images(
-        {"lecture_id": 123, "slide_priority": -20}
-    )
+    result = await service._handle_generate_lecture_images({"lecture_id": 123})
 
     assert result["enqueued"] == 1
     assert result["chain_remaining"] == 2
@@ -82,7 +84,8 @@ async def test_generate_lecture_images_enqueues_only_first_chained_slide():
 
     created = repository_factory.job.created[0]
     assert created["kind"] == "generate_lecture_slide"
-    assert created["priority"] == -20
+    # Slides inherit the neutral priority for their kind (no longer demoted).
+    assert created["priority"] == priority_for_kind("generate_lecture_slide")
     assert created["payload"]["slot_idx"] == 0
     assert created["payload"]["next_slide_payload"]["slot_idx"] == 1
     assert created["payload"]["next_slide_payload"]["next_slide_payload"]["slot_idx"] == 2
@@ -133,7 +136,7 @@ async def test_resume_lecture_images_enqueues_only_unfinished_chained_slides():
     )
     service._lecture_images_generator_service_instance = MagicMock(return_value=images_service)
 
-    result = await service._handle_resume_lecture_images({"lecture_id": 123, "slide_priority": -20})
+    result = await service._handle_resume_lecture_images({"lecture_id": 123})
 
     assert result["completed"] == 1
     assert result["resume_planned"] == 2
@@ -141,7 +144,7 @@ async def test_resume_lecture_images_enqueues_only_unfinished_chained_slides():
     assert result["chain_remaining"] == 1
     created = repository_factory.job.created[0]
     assert created["kind"] == "generate_lecture_slide"
-    assert created["priority"] == -20
+    assert created["priority"] == priority_for_kind("generate_lecture_slide")
     assert created["payload"]["slot_idx"] == 1
     assert created["payload"]["next_slide_payload"]["slot_idx"] == 2
 
@@ -200,13 +203,11 @@ async def test_generate_lecture_slide_enqueues_next_slide_after_success():
             "slot_idx": 0,
             "object_key": "TST100/images.json",
             "chunk_text": "first",
-            "slide_priority": -20,
             "next_slide_payload": {
                 "lecture_id": 123,
                 "slot_idx": 1,
                 "object_key": "TST100/images.json",
                 "chunk_text": "second",
-                "slide_priority": -20,
             },
         }
     )
@@ -215,7 +216,7 @@ async def test_generate_lecture_slide_enqueues_next_slide_after_success():
     assert len(repository_factory.job.created) == 1
     created = repository_factory.job.created[0]
     assert created["kind"] == "generate_lecture_slide"
-    assert created["priority"] == -20
+    assert created["priority"] == priority_for_kind("generate_lecture_slide")
     assert created["payload"]["slot_idx"] == 1
 
 

--- a/web/src/api/services/jobs-service.ts
+++ b/web/src/api/services/jobs-service.ts
@@ -19,6 +19,10 @@ export interface JobRow {
   parent_job_id?: number | null
   created_at?: string
   updated_at?: string
+  /** Best-effort model name for this job's kind (e.g. "claude-sonnet-4-6"), when one is obvious. */
+  model?: string | null
+  /** Relative frontend path to the lecture or topic this job concerns, when resolvable. */
+  link_path?: string | null
 }
 
 export async function getJob(jobId: number): Promise<JobRow> {

--- a/web/src/pages/Jobs.tsx
+++ b/web/src/pages/Jobs.tsx
@@ -1,3 +1,4 @@
+import { A } from '@solidjs/router'
 import { createResource, createSignal, For, onCleanup, Show } from 'solid-js'
 import {
   cancelJob,
@@ -250,6 +251,12 @@ export default function JobsPage() {
                       scope="col"
                       class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider"
                     >
+                      Model
+                    </th>
+                    <th
+                      scope="col"
+                      class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider"
+                    >
                       Status
                     </th>
                     <th
@@ -302,6 +309,11 @@ export default function JobsPage() {
                       <tr class="hover:bg-muted/30 transition-colors">
                         <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">{job.id}</td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm">{job.kind}</td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm">
+                          <Show when={job.model} fallback={<span class="text-muted">-</span>}>
+                            <span class="font-mono text-xs text-muted">{job.model}</span>
+                          </Show>
+                        </td>
                         <td class="px-6 py-4 whitespace-nowrap">
                           <span
                             class={`px-2 py-1 inline-flex text-xs leading-5 font-semibold rounded-full ${STATUS_STYLES[job.status]}`}
@@ -327,7 +339,11 @@ export default function JobsPage() {
                           )}
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm text-muted">
-                          {extractParams(job)}
+                          <Show when={job.link_path} fallback={<span>{extractParams(job)}</span>}>
+                            <A href={job.link_path as string} class="text-accent hover:underline">
+                              {extractParams(job)}
+                            </A>
+                          </Show>
                         </td>
                         <td class="px-6 py-4 text-sm text-muted">
                           <Show when={job.last_error} fallback={<span class="text-muted">-</span>}>


### PR DESCRIPTION
Admin jobs UI:
- Add a Model column (best-effort model name per job kind) and link the Params cell to the relevant lecture/topic page (prefers lecture). The backend resolves `model` and `link_path` on the job response.

Job priorities:
- Centralize scheduling priority as a function of job kind in models/job_priorities.py; JobRepository.create derives it when unset. This fixes a propagation bug where batch priority was only honored for the first job in a follow-up chain. Audio (and audio-dependent timeline) are demoted below the neutral default so slow jobs no longer starve fast image jobs. Removed scattered priority=1 / slide_priority magic.

Bug fixes:
- worker._build_audio_payload always returned None (its body was dead, unreachable code at the end of _build_timeline_payload), so batch audio regeneration only processed the first lecture. Restored the logic.
- jobs.py enqueue/cancel were sync handlers calling asyncio.create_task(hub.publish(...)) from a threadpool with no event loop, raising a swallowed RuntimeError and orphaning the coroutine ("coroutine was never awaited"); SSE events were never delivered. Made them async, run DB work via asyncio.to_thread, and await publish via a shared helper reading the hub from app state.

Tests: add job_priorities and worker follow-up unit tests; update job_service tests for the kind-based priority scheme.