### PR TITLE
Add freeform notes field to courses for guiding content generation

### DIFF
--- a/alembic/versions/b1c2d3e4f5a6_add_notes_field_to_courses.py
+++ b/alembic/versions/b1c2d3e4f5a6_add_notes_field_to_courses.py
@@ -1,0 +1,25 @@
+"""add_notes_field_to_courses
+
+Revision ID: b1c2d3e4f5a6
+Revises: a9b8c7d6e5f4
+Create Date: 2026-06-07 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b1c2d3e4f5a6"
+down_revision = "a9b8c7d6e5f4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("courses", sa.Column("notes", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("courses", "notes")

--- a/artificial_u/api/models/courses.py
+++ b/artificial_u/api/models/courses.py
@@ -45,6 +45,10 @@ class CourseBase(BaseModel):
     status: Literal["hidden", "published"] = Field(
         default="hidden", description="Course visibility status"
     )
+    notes: Optional[str] = Field(
+        None,
+        description="Optional user-provided notes to guide content generation for this course",
+    )
     language: Optional[str] = Field(None, description="Language code (e.g., 'en', 'fr')")
     # Attribution (not required for create)
     created_by: Optional[int] = Field(None, description="Student ID who created the course")
@@ -89,6 +93,10 @@ class CourseUpdate(BaseModel):
     )
     status: Optional[Literal["hidden", "published"]] = Field(
         None, description="Updated course visibility status"
+    )
+    notes: Optional[str] = Field(
+        None,
+        description="Optional user-provided notes to guide content generation for this course",
     )
     connected_course_ids: Optional[List[int]] = Field(
         None,

--- a/artificial_u/api/services/course_service.py
+++ b/artificial_u/api/services/course_service.py
@@ -352,6 +352,7 @@ class CourseApiService(BaseApiService[CoreCourse, CourseResponse, CoursesListRes
                 level=course_data.level,
                 professor_id=course_data.professor_id,  # Can be None for smart selection
                 description=course_data.description,
+                notes=course_data.notes,
                 weeks=course_data.total_weeks,
                 lectures_per_week=course_data.lectures_per_week,
                 created_by=created_by,

--- a/artificial_u/models/converters.py
+++ b/artificial_u/models/converters.py
@@ -283,6 +283,10 @@ def partial_course_to_xml(
         else:
             lines.append(f"  <{field}>{generate_marker}</{field}>")
 
+    notes = partial_attrs.get("notes")
+    if notes:
+        lines.append(f"  <user_notes>{escape_xml(str(notes))}</user_notes>")
+
     lines.append("</course>")
     return "\n".join(lines)
 

--- a/artificial_u/models/core.py
+++ b/artificial_u/models/core.py
@@ -204,6 +204,7 @@ class Course(BaseModel):
     total_weeks: int = 12
     language: Optional[str] = None
     status: Literal["hidden", "published"] = "hidden"
+    notes: Optional[str] = None
     department_id: Optional[int] = None
     professor_id: Optional[int] = None
     # Attribution

--- a/artificial_u/models/database.py
+++ b/artificial_u/models/database.py
@@ -39,6 +39,7 @@ class CourseModel(Base):
     total_weeks = Column(Integer, nullable=True, default=12)
     language = Column(String, nullable=True)
     status = Column(String, nullable=False, default="hidden")
+    notes = Column(Text, nullable=True)
     department_id = Column(Integer, ForeignKey("departments.id"), nullable=True)
     professor_id = Column(Integer, ForeignKey("professors.id"), nullable=True)
     # New attribution fields

--- a/artificial_u/models/repositories/course.py
+++ b/artificial_u/models/repositories/course.py
@@ -72,6 +72,7 @@ class CourseRepository(BaseRepository):
             total_weeks=db_course.total_weeks,
             language=language,
             status=db_course.status,
+            notes=getattr(db_course, "notes", None),
             department_id=db_course.department_id,
             professor_id=db_course.professor_id,
             created_by=db_course.created_by,
@@ -101,6 +102,7 @@ class CourseRepository(BaseRepository):
                 total_weeks=course.total_weeks,
                 language=course.language,
                 status=course.status,
+                notes=getattr(course, "notes", None),
                 department_id=course.department_id,
                 professor_id=course.professor_id,
                 created_by=course.created_by,
@@ -160,6 +162,7 @@ class CourseRepository(BaseRepository):
             db_course.total_weeks = course.total_weeks
             db_course.language = course.language
             db_course.status = course.status
+            db_course.notes = getattr(course, "notes", None)
             db_course.department_id = course.department_id
             db_course.professor_id = course.professor_id
             db_course.created_by = course.created_by

--- a/artificial_u/prompts/fr/lecture.py
+++ b/artificial_u/prompts/fr/lecture.py
@@ -36,6 +36,10 @@ LECTURE_PROMPT = PromptTemplate(
 
 {{freeform_prompt_text}}
 
+Remarque : Si le XML du cours contient un élément <user_notes>, il s'agit de notes fournies par
+l'utilisateur pour ce cours — traitez-les comme des consignes importantes lors de la génération
+de la séance.
+
 Instructions :
 
 1. Prenez connaissance des informations fournies pour comprendre le contexte de la séance.

--- a/artificial_u/prompts/fr/topics.py
+++ b/artificial_u/prompts/fr/topics.py
@@ -76,6 +76,10 @@ Structure XML requise :
 Informations sur le cours :
 {{course_xml}}
 
+Remarque : Si le XML du cours contient un élément <user_notes>, il s'agit de notes fournies par
+l'utilisateur pour ce cours — traitez-les comme des consignes importantes lors de la génération
+du contenu.
+
 {{prior_topics_context}}
 {{related_courses_topics_context}}
 

--- a/artificial_u/prompts/lecture.py
+++ b/artificial_u/prompts/lecture.py
@@ -38,6 +38,9 @@ LECTURE_PROMPT = PromptTemplate(
 
 {{freeform_prompt_text}}
 
+Note: If the course XML includes a <user_notes> element, those are user-provided notes for this
+course — treat them as important guidance when generating the lecture.
+
 Instructions:
 
 1. Review the provided information carefully to understand the context of the lecture.

--- a/artificial_u/prompts/topics.py
+++ b/artificial_u/prompts/topics.py
@@ -73,6 +73,9 @@ Required XML Structure:
 Course Information:
 {{course_xml}}
 
+Note: If the course XML includes a <user_notes> element, those are user-provided notes for this
+course — treat them as important guidance when generating content.
+
 {{prior_topics_context}}
 {{related_courses_topics_context}}
 

--- a/artificial_u/services/course_service.py
+++ b/artificial_u/services/course_service.py
@@ -64,6 +64,7 @@ class CourseService:
         department_id: Optional[int] = None,
         professor_id: Optional[int] = None,
         description: Optional[str] = None,
+        notes: Optional[str] = None,
         created_by: Optional[int] = None,
         created_with: Optional[str] = None,
         connected_course_ids: Optional[List[int]] = None,
@@ -121,9 +122,10 @@ class CourseService:
             language=language,
         )
 
-        # Set attribution fields if provided
+        # Set attribution and user-provided fields
         course.created_by = created_by
         course.created_with = created_with
+        course.notes = notes
 
         # Save course
         created_course, created_professor = self._save_course(

--- a/tests/api/test_courses.py
+++ b/tests/api/test_courses.py
@@ -413,6 +413,7 @@ def test_create_course(client: TestClient, mock_api_service):
     # CourseCreate includes created_by, created_with, created_at, updated_at, status fields by default
     expected_course_data = {
         **new_course_data,
+        "notes": None,
         "language": None,
         "created_by": None,
         "created_with": None,

--- a/tests/unit/models/test_course_repository.py
+++ b/tests/unit/models/test_course_repository.py
@@ -36,6 +36,7 @@ class TestCourseRepository:
         mock_course.professor_id = 1
         mock_course.created_by = 1
         mock_course.created_with = "test-llm"
+        mock_course.notes = None
         mock_course.image_url = None
         mock_course.image_created_with = None
         mock_course.created_at = None
@@ -156,6 +157,7 @@ class TestCourseRepository:
         mock_course1.professor_id = 1
         mock_course1.created_by = 1
         mock_course1.created_with = "test-llm"
+        mock_course1.notes = None
         mock_course1.image_url = None
         mock_course1.image_created_with = None
         mock_course1.created_at = None
@@ -175,6 +177,7 @@ class TestCourseRepository:
         mock_course2.professor_id = 2
         mock_course2.created_by = 2
         mock_course2.created_with = "test-llm-2"
+        mock_course2.notes = None
         mock_course2.image_url = None
         mock_course2.image_created_with = None
         mock_course2.created_at = None
@@ -215,6 +218,7 @@ class TestCourseRepository:
         mock_course.professor_id = 1
         mock_course.created_by = 1
         mock_course.created_with = "test-llm"
+        mock_course.notes = None
         mock_course.image_url = None
         mock_course.image_created_with = None
         mock_course.created_at = None

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -41,6 +41,7 @@ export interface Course {
   total_weeks: number
   connected_course_ids: number[]
   status: CourseStatus
+  notes?: string | null
   created_by?: number | null
   created_with?: string | null
   image_url?: string | null
@@ -89,6 +90,7 @@ export interface CourseCreate {
   level?: string | null
   professor_id?: number | null
   description: string
+  notes?: string | null
   lectures_per_week?: number
   total_weeks?: number
   created_with?: string | null
@@ -103,6 +105,7 @@ export interface CourseUpdate {
   level?: string | null
   professor_id?: number | null
   description?: string
+  notes?: string | null
   lectures_per_week?: number
   total_weeks?: number
   status?: CourseStatus

--- a/web/src/components/courses/CourseForm.tsx
+++ b/web/src/components/courses/CourseForm.tsx
@@ -43,6 +43,7 @@ const CourseForm: Component<CourseFormProps> = (props) => {
     level: null,
     professor_id: null,
     description: '',
+    notes: null,
     lectures_per_week: null,
     total_weeks: null,
     freeform_prompt: '',
@@ -65,6 +66,7 @@ const CourseForm: Component<CourseFormProps> = (props) => {
         level: c.level || '',
         professor_id: c.professor_id,
         description: c.description || '',
+        notes: c.notes || null,
         lectures_per_week: c.lectures_per_week,
         total_weeks: c.total_weeks,
         freeform_prompt: '', // Reset generate prompt on edit
@@ -294,6 +296,7 @@ const CourseForm: Component<CourseFormProps> = (props) => {
       level: null,
       professor_id: null,
       description: '',
+      notes: null,
       lectures_per_week: null,
       total_weeks: null,
       freeform_prompt: '',
@@ -476,6 +479,24 @@ const CourseForm: Component<CourseFormProps> = (props) => {
           }}
           disabled={isDisabled()}
           required
+        />
+      </FormField>
+
+      <FormField
+        label={t().courses.form.notesLabel}
+        name="notes"
+        helperText={t().courses.form.notesHelper}
+        error={validationErrors().notes}
+      >
+        <Textarea
+          name="notes"
+          rows={3}
+          placeholder={t().courses.form.notesPlaceholder}
+          value={formData().notes || ''}
+          onChange={(v) => {
+            handleInputChange('notes', v || null)
+          }}
+          disabled={isDisabled()}
         />
       </FormField>
 

--- a/web/src/components/courses/types.ts
+++ b/web/src/components/courses/types.ts
@@ -7,6 +7,7 @@ export interface CourseFormData {
   level: string | null // Will be "Undergraduate", "Graduate", or null for AI determination
   professor_id: number | null // Will be number for submission, null if not selected
   description: string
+  notes?: string | null // Optional user notes to guide content generation
   lectures_per_week?: number | null // Optional field
   total_weeks?: number | null // Optional field
 

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -299,6 +299,11 @@ export const en = {
       lecturesPerWeekLabel: 'Lectures per Week (Optional)',
       totalWeeksLabel: 'Total Weeks (Optional)',
       descriptionLabel: 'Description',
+      notesLabel: 'Course Notes (Optional)',
+      notesPlaceholder:
+        'e.g. This course is taught in English with French vocabulary integrated throughout. Do not generate lectures entirely in French.',
+      notesHelper:
+        'Optional notes to guide content generation. These are passed to the AI when generating topics and lectures. Not auto-populated by Generate Details.',
       aiPromptLabel: 'AI Generation Prompt (Optional)',
       departmentPlaceholder: '-- Select Department (Optional) --',
       professorPlaceholder: '-- Select Professor (Optional) --',

--- a/web/src/i18n/locales/es.ts
+++ b/web/src/i18n/locales/es.ts
@@ -300,6 +300,11 @@ export const es = {
       lecturesPerWeekLabel: 'Clases por semana (opcional)',
       totalWeeksLabel: 'Total de semanas (opcional)',
       descriptionLabel: 'Descripción',
+      notesLabel: 'Notas del curso (opcional)',
+      notesPlaceholder:
+        'Ej. Este curso se imparte en inglés con vocabulario francés integrado. No generar lecciones completamente en francés.',
+      notesHelper:
+        'Notas opcionales para guiar la generación de contenido. Se envían a la IA al generar temas y lecciones. No se completan automáticamente con Generar detalles.',
       aiPromptLabel: 'Indicación de generación IA (opcional)',
       departmentPlaceholder: '-- Seleccionar departamento (opcional) --',
       professorPlaceholder: '-- Seleccionar profesor (opcional) --',

--- a/web/src/i18n/locales/fr.ts
+++ b/web/src/i18n/locales/fr.ts
@@ -300,6 +300,11 @@ export const fr = {
       lecturesPerWeekLabel: 'Cours par semaine (optionnel)',
       totalWeeksLabel: 'Nombre total de semaines (optionnel)',
       descriptionLabel: 'Description',
+      notesLabel: 'Notes de cours (optionnel)',
+      notesPlaceholder:
+        'Ex. Ce cours est enseigné en anglais avec du vocabulaire français intégré. Ne pas générer les leçons entièrement en français.',
+      notesHelper:
+        "Notes optionnelles pour guider la génération de contenu. Elles sont transmises à l'IA lors de la génération des sujets et des séances. Non remplies automatiquement par Générer les détails.",
       aiPromptLabel: 'Invite de génération IA (optionnel)',
       departmentPlaceholder: '-- Sélectionner un département (optionnel) --',
       professorPlaceholder: '-- Sélectionner un professeur (optionnel) --',

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -299,6 +299,10 @@ export const zh = {
       lecturesPerWeekLabel: '每周讲座数（可选）',
       totalWeeksLabel: '总周数（可选）',
       descriptionLabel: '描述',
+      notesLabel: '课程备注（可选）',
+      notesPlaceholder: '例如：本课程以英语授课，并融入法语词汇。请勿将课程全部以法语生成。',
+      notesHelper:
+        '可选备注，用于指导内容生成。生成主题和讲座时将传递给AI。"生成详情"不会自动填写此字段。',
       aiPromptLabel: 'AI生成提示（可选）',
       departmentPlaceholder: '-- 选择系（可选）--',
       professorPlaceholder: '-- 选择教授（可选）--',

--- a/web/src/pages/CourseDetail.tsx
+++ b/web/src/pages/CourseDetail.tsx
@@ -423,6 +423,7 @@ const CourseDetail: Component = () => {
       level: formData.level ?? undefined,
       professor_id: formData.professor_id ?? undefined,
       description: formData.description,
+      notes: formData.notes ?? undefined,
       lectures_per_week: formData.lectures_per_week ?? undefined,
       total_weeks: formData.total_weeks ?? undefined,
       // topics are not part of CourseUpdate in types.ts, handle separately if needed

--- a/web/src/pages/Courses.tsx
+++ b/web/src/pages/Courses.tsx
@@ -415,6 +415,7 @@ const Courses: Component = () => {
       level: formData.level ?? undefined,
       professor_id: formData.professor_id ?? undefined,
       description: formData.description,
+      notes: formData.notes ?? undefined,
       lectures_per_week: formData.lectures_per_week ?? undefined,
       total_weeks: formData.total_weeks ?? undefined,
       created_with: formData.created_with ?? undefined,


### PR DESCRIPTION
Adds an optional `notes` Text column to the courses table (Alembic
migration included). Notes are user-supplied free text that travel
through the full stack — DB model, core domain model, repository CRUD,
Pydantic API models, and the core/API service layers — into the
`partial_course_to_xml` converter as a `<user_notes>` element. Topic
and lecture prompt templates (EN + FR) now include a note instructing
the LLM to treat that element as important guidance.

The Generate Details feature intentionally never populates the notes
field, keeping it entirely user-controlled.

Frontend: CourseForm gains a Notes textarea with i18n labels,
placeholders, and helper text in EN, FR, ES, and ZH. The field is
wired through CourseFormData, CourseCreate/Update types, and the
create/update handlers in Courses.tsx and CourseDetail.tsx.

https://claude.ai/code/session_019uZVhiWyrwUxujidz8AVR2