### PR TITLE
Fix transcript UTF-8 encoding and remove TTS preprocessing

### DIFF
--- a/artificial_u/api/routers/lectures.py
+++ b/artificial_u/api/routers/lectures.py
@@ -974,6 +974,98 @@ async def upload_lecture_audio(
 
 
 @router.post(
+    "/{lecture_id}/recreate-transcript",
+    summary="Recreate lecture transcript",
+    description=(
+        "Re-upload the lecture's stored content as the transcript file, overwriting the existing "
+        "S3 object. Useful for fixing encoding issues or applying updated storage settings. "
+        "Admin only. Returns the updated lecture."
+    ),
+    responses={
+        404: {"description": "Lecture not found"},
+        400: {"description": "Lecture has no content to upload"},
+        403: {"description": "Admin access required"},
+    },
+    dependencies=[require_role("admin")],
+)
+async def recreate_lecture_transcript(
+    lecture_id: int = Path(..., description="The ID of the lecture"),
+    repository_factory: RepositoryFactory = Depends(get_repository_factory),
+    storage_service: StorageService = Depends(get_storage_service),
+):
+    logger = logging.getLogger(__name__)
+
+    lecture = repository_factory.lecture.get(lecture_id)
+    if not lecture:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=f"Lecture {lecture_id} not found"
+        )
+
+    if not lecture.content:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Lecture {lecture_id} has no content to upload as transcript",
+        )
+
+    course = repository_factory.course.get(lecture.course_id)
+    topic = repository_factory.topic.get(lecture.topic_id) if lecture.topic_id else None
+
+    if not course:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Lecture must be associated with a valid course",
+        )
+
+    if not topic:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Lecture must be associated with a valid topic",
+        )
+
+    try:
+        object_key = storage_service.generate_lecture_key(
+            course_code=str(course.code),
+            week_number=int(topic.week),
+            lecture_order=int(topic.order),
+            extension="txt",
+        )
+
+        success, transcript_url = await storage_service.upload_lecture_file(
+            file_data=lecture.content.encode("utf-8"),
+            object_name=object_key,
+            content_type="text/plain; charset=utf-8",
+        )
+
+        if not success or not transcript_url:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to upload transcript to storage",
+            )
+
+        logger.info(f"Recreated transcript for lecture {lecture_id} at {transcript_url}")
+
+        lecture.transcript_url = transcript_url
+        updated_lecture = repository_factory.lecture.update(lecture)
+
+        if not updated_lecture:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to update lecture with transcript URL",
+            )
+
+        return updated_lecture
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error recreating transcript for lecture {lecture_id}: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to recreate transcript: {str(e)}",
+        )
+
+
+@router.post(
     "/{lecture_id}/generate-summary",
     response_model=Lecture,
     status_code=status.HTTP_200_OK,

--- a/artificial_u/services/lecture_generator_service.py
+++ b/artificial_u/services/lecture_generator_service.py
@@ -864,21 +864,11 @@ class LectureGeneratorService:
         topic_id: int,
         content_text: str,
     ) -> Optional[str]:
-        """Upload generated lecture text to storage and return its URL.
-
-        The text is normalized for TTS compatibility before being uploaded as a transcript.
-        This ensures that users can submit the transcript to external TTS services
-        and get good results.
-        """
+        """Upload generated lecture text to storage and return its URL."""
         if not self.storage_service or not content_text:
             return None
 
         try:
-            # Normalize text for TTS compatibility before uploading as transcript
-            from artificial_u.audio.speech_processor import SpeechProcessor
-
-            speech_processor = SpeechProcessor(logger=self.logger)
-            normalized_text = speech_processor.normalize_text(content_text)
             course = self.course_service.get_course(course_id)
             topic = self.topic_service.get_topic(topic_id)
 
@@ -894,9 +884,9 @@ class LectureGeneratorService:
             )
 
             success, url = await self.storage_service.upload_lecture_file(
-                file_data=normalized_text.encode("utf-8"),
+                file_data=content_text.encode("utf-8"),
                 object_name=object_key,
-                content_type="text/plain",
+                content_type="text/plain; charset=utf-8",
             )
             return url if success else None
         except Exception as e:

--- a/web/src/api/config.ts
+++ b/web/src/api/config.ts
@@ -106,6 +106,7 @@ export const ENDPOINTS = {
     enqueueGenerateTimeline: (id: number) => `/v1/lectures/${String(id)}/generate-timeline/enqueue`,
     enqueueGenerateImages: (id: number) => `/v1/lectures/${String(id)}/generate-images/enqueue`,
     enqueueResumeImages: (id: number) => `/v1/lectures/${String(id)}/resume-images/enqueue`,
+    recreateTranscript: (id: number) => `/v1/lectures/${String(id)}/recreate-transcript`,
     generateSummary: (id: number) => `/v1/lectures/${String(id)}/generate-summary`,
     clearSummary: (id: number) => `/v1/lectures/${String(id)}/summary`,
     uploadAudio: (id: number) => `/v1/lectures/${String(id)}/upload-audio`,

--- a/web/src/api/services/lecture-service.ts
+++ b/web/src/api/services/lecture-service.ts
@@ -160,6 +160,10 @@ export const lectureService = {
     return httpClient.post(ENDPOINTS.lectures.enqueueResumeImages(lectureId), undefined)
   },
 
+  recreateLectureTranscript: (lectureId: number): Promise<Lecture> => {
+    return httpClient.post<Lecture>(ENDPOINTS.lectures.recreateTranscript(lectureId), undefined)
+  },
+
   createLecture: (data: LectureCreate): Promise<Lecture> => {
     return httpClient.post<Lecture>(ENDPOINTS.lectures.list, data)
   },

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -694,6 +694,8 @@ export const en = {
       'Regenerate timeline? This replaces the word timeline and will remap the existing lecture image timeline without regenerating images.',
     confirmRegenerateImages:
       'Regenerate lecture images? This will delete existing slide images where possible and create a new image timeline with newly generated images.',
+    recreateTranscript: 'Recreate Transcript',
+    recreatingTranscript: 'Recreating Transcript...',
     generatingSummary: 'Generating Summary...',
     regeneratingSummary: 'Regenerating Summary...',
     regenerateSummary: 'Regenerate Summary',

--- a/web/src/i18n/locales/es.ts
+++ b/web/src/i18n/locales/es.ts
@@ -715,6 +715,8 @@ export const es = {
       '¿Regenerar cronología? Esto reemplaza la cronología de palabras y volverá a mapear la cronología de imágenes de la lección existente sin regenerar las imágenes.',
     confirmRegenerateImages:
       '¿Regenerar imágenes de la lección? Esto eliminará las imágenes de diapositivas existentes cuando sea posible y creará una nueva cronología de imágenes con imágenes recién generadas.',
+    recreateTranscript: 'Recrear transcripción',
+    recreatingTranscript: 'Recreando transcripción...',
     generatingSummary: 'Generando resumen...',
     regeneratingSummary: 'Regenerando resumen...',
     regenerateSummary: 'Regenerar resumen',

--- a/web/src/i18n/locales/fr.ts
+++ b/web/src/i18n/locales/fr.ts
@@ -696,6 +696,8 @@ export const fr = {
       'Régénérer la chronologie ? Cela remplace la chronologie des mots et remappera la chronologie des images de la conférence existante sans régénérer les images.',
     confirmRegenerateImages:
       "Régénérer les images de la conférence ? Cela supprimera les images de diapositives existantes si possible et créera une nouvelle chronologie d'images avec des images fraîchement générées.",
+    recreateTranscript: 'Recréer la transcription',
+    recreatingTranscript: 'Recréation en cours...',
     generatingSummary: 'Génération du résumé...',
     regeneratingSummary: 'Régénération du résumé...',
     regenerateSummary: 'Régénérer le résumé',

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -701,6 +701,8 @@ export const zh = {
       '重新生成时间轴吗？这将替换单词时间轴，并在不重新生成图片的情况下重新映射现有的讲座图片时间轴。',
     confirmRegenerateImages:
       '重新生成讲座图片吗？这将尽可能删除现有幻灯片图片，并使用新生成的图片创建新的图片时间轴。',
+    recreateTranscript: '重新创建转录',
+    recreatingTranscript: '正在重新创建转录...',
     generatingSummary: '正在生成摘要...',
     regeneratingSummary: '正在重新生成摘要...',
     regenerateSummary: '重新生成摘要',

--- a/web/src/pages/LectureDetail.tsx
+++ b/web/src/pages/LectureDetail.tsx
@@ -100,9 +100,7 @@ const LectureDetailView: Component<{
     try {
       await lectureService.recreateLectureTranscript(props.lecture.id)
     } catch (error) {
-      setTranscriptError(
-        error instanceof Error ? error.message : 'Failed to recreate transcript'
-      )
+      setTranscriptError(error instanceof Error ? error.message : 'Failed to recreate transcript')
     } finally {
       setIsRecreatingTranscript(false)
     }

--- a/web/src/pages/LectureDetail.tsx
+++ b/web/src/pages/LectureDetail.tsx
@@ -46,6 +46,8 @@ const LectureDetailView: Component<{
   const [timelineError, setTimelineError] = createSignal('')
   const [isGeneratingImages, setIsGeneratingImages] = createSignal(false)
   const [imagesError, setImagesError] = createSignal('')
+  const [isRecreatingTranscript, setIsRecreatingTranscript] = createSignal(false)
+  const [transcriptError, setTranscriptError] = createSignal('')
   const confirmRegeneration = (message: string) => window.confirm(message)
   const uploadAudioDisabled = () =>
     props.isUploadingAudio ||
@@ -89,6 +91,20 @@ const LectureDetailView: Component<{
       setImagesError(error instanceof Error ? error.message : 'Failed to resume lecture images')
     } finally {
       setIsGeneratingImages(false)
+    }
+  }
+
+  const handleRecreateTranscript = async () => {
+    setIsRecreatingTranscript(true)
+    setTranscriptError('')
+    try {
+      await lectureService.recreateLectureTranscript(props.lecture.id)
+    } catch (error) {
+      setTranscriptError(
+        error instanceof Error ? error.message : 'Failed to recreate transcript'
+      )
+    } finally {
+      setIsRecreatingTranscript(false)
     }
   }
 
@@ -259,6 +275,20 @@ const LectureDetailView: Component<{
                   >
                     {t().lectureDetail.resumeImages}
                   </MagicButton>
+                </Show>
+                <MagicButton
+                  variant="primary"
+                  size="sm"
+                  class="min-h-[44px] sm:min-h-[32px] w-full sm:w-auto flex items-center justify-center whitespace-nowrap"
+                  onClick={() => void handleRecreateTranscript()}
+                  disabled={isRecreatingTranscript()}
+                >
+                  {isRecreatingTranscript()
+                    ? t().lectureDetail.recreatingTranscript
+                    : t().lectureDetail.recreateTranscript}
+                </MagicButton>
+                <Show when={transcriptError()}>
+                  <span class="text-xs text-red-400">{transcriptError()}</span>
                 </Show>
                 <label
                   for="audio-file-upload"


### PR DESCRIPTION
Two bugs in _upload_transcript_and_get_url:

1. Content-Type was "text/plain" with no charset, so browsers defaulted
   to Latin-1 interpretation of the UTF-8 bytes, producing classic
   mojibake (é → Ã©, à → Ã , etc.) for any accented or non-ASCII text.
   Fixed by setting "text/plain; charset=utf-8".

2. The transcript was run through SpeechProcessor.normalize_text() with
   the ElevenLabs backend, which injects SSML <break> tags and rewrites
   dashes/hyphens. A human-readable transcript should be the original
   prose, not TTS markup. Removed the normalization step entirely.

https://claude.ai/code/session_012G1FpD1RwRf9UwMDpuiY9A