### PR TITLE
Rebuild admin jobs page as a mobile-first live dashboard

### DIFF
--- a/artificial_u/api/routers/jobs.py
+++ b/artificial_u/api/routers/jobs.py
@@ -37,13 +37,21 @@ def _tts_backend_name(settings) -> Optional[str]:
     return backend or None
 
 
-def _job_model_name(kind: str, payload: Any, factory=None) -> Optional[str]:
+def _job_model_name(
+    kind: str, payload: Any, result: Any = None, factory=None, cache: Optional[dict] = None
+) -> Optional[str]:
     """
-    Best-effort model name for a job. Payload-level overrides take precedence,
-    then global preference overrides (admin settings), then environment defaults.
+    Best-effort model name for a job. The backend recorded in the job result at
+    generation time takes precedence, then payload-level overrides, then global
+    preference overrides (admin settings), then environment defaults.
 
-    Note: per-professor / per-voice overrides applied at runtime are not resolved here.
+    ``cache`` memoizes preference lookups across the rows of one request.
     """
+    result = result if isinstance(result, dict) else {}
+    recorded = result.get("tts_backend")
+    if recorded:
+        return str(recorded)
+
     payload = payload if isinstance(payload, dict) else {}
     override = payload.get("model_name_override")
     if override:
@@ -85,9 +93,16 @@ def _job_model_name(kind: str, payload: Any, factory=None) -> Optional[str]:
 
     scope, default = entry
     if factory is not None:
-        pref = factory.preference.get_global(scope)
-        if pref:
-            return pref.value
+        cache_key = ("pref", scope)
+        if cache is not None and cache_key in cache:
+            pref_value = cache[cache_key]
+        else:
+            pref = factory.preference.get_global(scope)
+            pref_value = pref.value if pref else None
+            if cache is not None:
+                cache[cache_key] = pref_value
+        if pref_value:
+            return pref_value
 
     return default
 
@@ -102,14 +117,16 @@ def _coerce_int(value: Any) -> Optional[int]:
     return None
 
 
-def _job_link_path(payload: Any, result: Any, factory=None) -> Optional[str]:
+def _job_link_path(
+    payload: Any, result: Any, factory=None, cache: Optional[dict] = None
+) -> Optional[str]:
     """
     Resolve a relative frontend path to the lecture or topic a job concerns.
 
     Prefers the lecture when both a lecture and topic are present. The lecture /
     topic detail routes are nested under a course, so a course id is required; it
     is taken from the payload/result when available and otherwise resolved via a
-    single primary-key lookup.
+    primary-key lookup memoized in ``cache`` across the rows of one request.
     """
     payload = payload if isinstance(payload, dict) else {}
     result = result if isinstance(result, dict) else {}
@@ -127,24 +144,32 @@ def _job_link_path(payload: Any, result: Any, factory=None) -> Optional[str]:
     topic_id = _pick("topic_id")
     course_id = _pick("course_id")
 
+    def _resolve_course_id(kind: str, entity_id: int, repo) -> Optional[int]:
+        cache_key = (kind, entity_id)
+        if cache is not None and cache_key in cache:
+            return cache[cache_key]
+        entity = repo.get(entity_id)
+        resolved = getattr(entity, "course_id", None)
+        if cache is not None:
+            cache[cache_key] = resolved
+        return resolved
+
     if lecture_id is not None:
         if course_id is None and factory is not None:
-            lecture = factory.lecture.get(lecture_id)
-            course_id = getattr(lecture, "course_id", None)
+            course_id = _resolve_course_id("lecture_course", lecture_id, factory.lecture)
         if course_id is not None:
             return f"/courses/{course_id}/lectures/{lecture_id}"
 
     if topic_id is not None:
         if course_id is None and factory is not None:
-            topic = factory.topic.get(topic_id)
-            course_id = getattr(topic, "course_id", None)
+            course_id = _resolve_course_id("topic_course", topic_id, factory.topic)
         if course_id is not None:
             return f"/courses/{course_id}/topics/{topic_id}"
 
     return None
 
 
-def _job_row_response(r, factory=None) -> dict:
+def _job_row_response(r, factory=None, cache: Optional[dict] = None) -> dict:
     return {
         "id": r.id,
         "kind": r.kind,
@@ -160,8 +185,8 @@ def _job_row_response(r, factory=None) -> dict:
         "result": r.result,
         "duration_ms": _duration_ms_from_result(r.result),
         "parent_job_id": getattr(r, "parent_job_id", None),
-        "model": _job_model_name(r.kind, r.payload, factory),
-        "link_path": _job_link_path(r.payload, r.result, factory),
+        "model": _job_model_name(r.kind, r.payload, r.result, factory, cache),
+        "link_path": _job_link_path(r.payload, r.result, factory, cache),
     }
 
 
@@ -188,7 +213,8 @@ def _active_job_snapshot(
     if kinds_set:
         rows = [row for row in rows if row.kind in kinds_set]
     rows.sort(key=lambda row: row.created_at, reverse=True)
-    return [_job_row_response(row, factory) for row in rows]
+    cache: dict = {}
+    return [_job_row_response(row, factory, cache) for row in rows]
 
 
 class EnqueueJob(BaseModel):
@@ -253,34 +279,46 @@ async def enqueue(
 @router.get("", dependencies=[Depends(require_auth)])
 def list_jobs(
     status: Optional[str] = None,
-    limit: int = 50,
+    limit: int = 25,
     kind: Optional[str] = None,
     lecture_id: Optional[int] = None,
     topic_id: Optional[int] = None,
     course_id: Optional[int] = None,
     parent_id: Optional[int] = None,
+    before_id: Optional[int] = None,
     repository_factory: RepositoryFactory = Depends(get_repository_factory),
 ):
+    limit = max(1, min(limit, 100))
     repo = repository_factory.job
+    # Fetch one extra row to detect whether another page exists.
     rows = repo.list(
         status=status,
-        limit=limit,
+        limit=limit + 1,
         kind=kind,
         lecture_id=lecture_id,
         topic_id=topic_id,
         course_id=course_id,
         parent_id=parent_id,
+        before_id=before_id,
     )
-    return [_job_row_response(r, repository_factory) for r in rows]
+    has_more = len(rows) > limit
+    rows = rows[:limit]
+    cache: dict = {}
+    jobs = [_job_row_response(r, repository_factory, cache) for r in rows]
+    return {
+        "jobs": jobs,
+        "has_more": has_more,
+        "next_before_id": rows[-1].id if rows and has_more else None,
+    }
 
 
 @router.get("/summary", dependencies=[Depends(require_auth)])
 def jobs_summary(
+    window_hours: int = 24,
     repository_factory: RepositoryFactory = Depends(get_repository_factory),
 ):
-    repo = repository_factory.job
-    counts = repo.summary_counts()
-    return {k: v for k, v in counts}
+    window_hours = max(1, min(window_hours, 24 * 7))
+    return repository_factory.job.dashboard_stats(window_hours=window_hours)
 
 
 @router.get("/stream")
@@ -364,7 +402,8 @@ def get_job_children(
     if not repo.get(job_id):
         raise HTTPException(404, "job not found")
     rows = repo.list(parent_id=job_id, limit=200)
-    return [_job_row_response(r, repository_factory) for r in rows]
+    cache: dict = {}
+    return [_job_row_response(r, repository_factory, cache) for r in rows]
 
 
 @router.post("/{job_id}/cancel", dependencies=[Depends(require_auth)])

--- a/artificial_u/models/repositories/job.py
+++ b/artificial_u/models/repositories/job.py
@@ -61,6 +61,7 @@ class JobRepository(BaseRepository):
         topic_id: Optional[int] = None,
         course_id: Optional[int] = None,
         parent_id: Optional[int] = None,
+        before_id: Optional[int] = None,
     ) -> List[JobModel]:
         with self.get_session() as session:
             stmt = select(JobModel)
@@ -70,6 +71,8 @@ class JobRepository(BaseRepository):
                 stmt = stmt.where(JobModel.kind == kind)
             if parent_id is not None:
                 stmt = stmt.where(JobModel.parent_job_id == parent_id)
+            if before_id is not None:
+                stmt = stmt.where(JobModel.id < before_id)
 
             # JSONB payload filters (best-effort on Postgres)
             if lecture_id is not None:
@@ -101,7 +104,9 @@ class JobRepository(BaseRepository):
                     )
                 )
 
-            stmt = stmt.order_by(desc(JobModel.created_at)).limit(limit)
+            # id DESC matches created_at DESC for the serial PK and keeps keyset
+            # pagination (before_id) stable while new jobs stream in.
+            stmt = stmt.order_by(desc(JobModel.id)).limit(limit)
             return list(session.execute(stmt).scalars())
 
     def reserve_one_skip_locked(self) -> Optional[JobModel]:
@@ -259,6 +264,77 @@ class JobRepository(BaseRepository):
                 "counts": counts,
                 "avg_wait_seconds": avg_wait_seconds,
                 "failed_last_hour": failed_last_hour_count,
+            }
+
+    def dashboard_stats(self, *, window_hours: int = 24) -> Dict[str, Any]:
+        """
+        Aggregates backing the admin jobs dashboard.
+
+        Returns counts by status (all time), queue health (avg queued wait,
+        failures in the last hour), and per-kind activity over the recent
+        window: job count plus avg/p50 duration of done jobs, sourced from
+        the worker telemetry stored at result._job_telemetry.duration_ms.
+        """
+        from sqlalchemy import Numeric, cast
+
+        now = self._now()
+        cutoff = now - dt.timedelta(hours=window_hours)
+        with self.get_session() as session:
+            counts_rows = session.execute(
+                select(JobModel.status, func.count()).group_by(JobModel.status)
+            ).all()
+            counts: Dict[str, int] = {str(s): int(c) for s, c in counts_rows}
+
+            avg_wait = session.execute(
+                select(func.avg(func.extract("epoch", now - JobModel.created_at))).where(
+                    JobModel.status == "queued"
+                )
+            ).scalar()
+            avg_wait_seconds = float(avg_wait) if avg_wait is not None else 0.0
+
+            failed_last_hour = session.execute(
+                select(func.count())
+                .select_from(JobModel)
+                .where(
+                    and_(
+                        JobModel.status == "failed",
+                        JobModel.updated_at >= now - dt.timedelta(hours=1),
+                    )
+                )
+            ).scalar()
+
+            duration = cast(JobModel.result["_job_telemetry"]["duration_ms"].astext, Numeric)
+            is_done = JobModel.status == "done"
+            kind_rows = session.execute(
+                select(
+                    JobModel.kind,
+                    func.count().label("count"),
+                    func.avg(duration).filter(is_done).label("avg_duration_ms"),
+                    func.percentile_cont(0.5)
+                    .within_group(duration.asc())
+                    .filter(is_done)
+                    .label("p50_duration_ms"),
+                )
+                .where(JobModel.updated_at >= cutoff)
+                .group_by(JobModel.kind)
+                .order_by(func.count().desc())
+            ).all()
+            kinds_recent = [
+                {
+                    "kind": str(kind),
+                    "count": int(count),
+                    "avg_duration_ms": float(avg) if avg is not None else None,
+                    "p50_duration_ms": float(p50) if p50 is not None else None,
+                }
+                for kind, count, avg, p50 in kind_rows
+            ]
+
+            return {
+                "counts": counts,
+                "avg_wait_seconds": avg_wait_seconds,
+                "failed_last_hour": int(failed_last_hour or 0),
+                "window_hours": window_hours,
+                "kinds_recent": kinds_recent,
             }
 
     def sweep_stuck(self, *, visibility_timeout_seconds: int) -> int:

--- a/artificial_u/services/lecture_generator_service.py
+++ b/artificial_u/services/lecture_generator_service.py
@@ -499,6 +499,7 @@ class LectureGeneratorService:
             "timeline_url": updated.timeline_url,
             "voice_id": updated.voice_id,
             "duration": updated.duration,
+            "tts_backend": backend_name,
         }
 
     async def generate_lecture_timeline(self, lecture_id: int) -> Dict[str, Any]:

--- a/artificial_u/services/tts_service.py
+++ b/artificial_u/services/tts_service.py
@@ -68,7 +68,7 @@ class TTSService:
             from artificial_u.integrations.tts.factory import create_tts_backend
 
             self.backend = create_tts_backend(
-                backend_name="elevenlabs",
+                backend_name=self.settings.tts_backend or "elevenlabs",
                 api_key=api_key,
                 logger=self.logger,
             )

--- a/tests/api/test_jobs.py
+++ b/tests/api/test_jobs.py
@@ -1,0 +1,176 @@
+"""
+Unit tests for the jobs API endpoints, mocking the repository factory.
+"""
+
+import datetime as dt
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from artificial_u.api.dependencies import get_repository_factory
+
+
+def _job_row(job_id, *, kind="generate_lecture", status="done", payload=None, result=None):
+    now = dt.datetime(2026, 7, 22, 12, 0, 0)
+    return SimpleNamespace(
+        id=job_id,
+        kind=kind,
+        status=status,
+        attempts=1,
+        max_attempts=2,
+        priority=0,
+        run_after=now,
+        created_at=now,
+        updated_at=now,
+        last_error=None,
+        payload=payload or {},
+        result=result,
+        parent_job_id=None,
+    )
+
+
+@pytest.fixture
+def mock_repository_factory():
+    from artificial_u.api.app import app
+
+    factory = MagicMock()
+    factory.preference.get_global.return_value = None
+    factory.lecture.get.return_value = SimpleNamespace(course_id=7)
+    factory.topic.get.return_value = SimpleNamespace(course_id=7)
+
+    app.dependency_overrides[get_repository_factory] = lambda: factory
+    yield factory
+    app.dependency_overrides.pop(get_repository_factory, None)
+
+
+@pytest.mark.unit
+def test_list_jobs_envelope_and_has_more(client: TestClient, mock_repository_factory):
+    """The list endpoint fetches limit+1 rows and reports has_more/next_before_id."""
+    rows = [_job_row(i) for i in range(30, 19, -1)]  # 11 rows for limit=10
+    mock_repository_factory.job.list.return_value = rows
+
+    response = client.get("/api/v1/jobs?limit=10")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["jobs"]) == 10
+    assert data["has_more"] is True
+    assert data["next_before_id"] == 21
+    mock_repository_factory.job.list.assert_called_once_with(
+        status=None,
+        limit=11,
+        kind=None,
+        lecture_id=None,
+        topic_id=None,
+        course_id=None,
+        parent_id=None,
+        before_id=None,
+    )
+
+
+@pytest.mark.unit
+def test_list_jobs_last_page(client: TestClient, mock_repository_factory):
+    mock_repository_factory.job.list.return_value = [_job_row(3), _job_row(2)]
+
+    response = client.get("/api/v1/jobs?limit=10")
+    data = response.json()
+    assert len(data["jobs"]) == 2
+    assert data["has_more"] is False
+    assert data["next_before_id"] is None
+
+
+@pytest.mark.unit
+def test_list_jobs_forwards_filters(client: TestClient, mock_repository_factory):
+    mock_repository_factory.job.list.return_value = []
+
+    response = client.get(
+        "/api/v1/jobs?status=done&kind=generate_lecture_slide&before_id=100&limit=5"
+    )
+    assert response.status_code == 200
+    mock_repository_factory.job.list.assert_called_once_with(
+        status="done",
+        limit=6,
+        kind="generate_lecture_slide",
+        lecture_id=None,
+        topic_id=None,
+        course_id=None,
+        parent_id=None,
+        before_id=100,
+    )
+
+
+@pytest.mark.unit
+def test_audio_job_model_prefers_recorded_backend(client: TestClient, mock_repository_factory):
+    """The tts backend recorded in the job result wins over the global default."""
+    mock_repository_factory.job.list.return_value = [
+        _job_row(1, kind="generate_lecture_audio", result={"tts_backend": "mistral"}),
+        _job_row(2, kind="generate_lecture_audio", result=None),
+    ]
+
+    data = client.get("/api/v1/jobs").json()
+    from artificial_u.config import get_settings
+
+    assert data["jobs"][0]["model"] == "mistral"
+    # Without a recorded backend the configured default still applies.
+    expected_default = (get_settings().tts_backend or "").strip().lower() or None
+    assert data["jobs"][1]["model"] == expected_default
+
+
+@pytest.mark.unit
+def test_job_model_payload_override(client: TestClient, mock_repository_factory):
+    mock_repository_factory.job.list.return_value = [
+        _job_row(1, payload={"model_name_override": "custom-model"}),
+    ]
+
+    data = client.get("/api/v1/jobs").json()
+    assert data["jobs"][0]["model"] == "custom-model"
+
+
+@pytest.mark.unit
+def test_list_jobs_memoizes_preference_and_link_lookups(
+    client: TestClient, mock_repository_factory
+):
+    """Preference and lecture->course lookups run once per request, not once per row."""
+    payload = {"lecture_id": 5}
+    mock_repository_factory.job.list.return_value = [
+        _job_row(i, kind="generate_lecture", payload=payload) for i in range(10, 0, -1)
+    ]
+
+    response = client.get("/api/v1/jobs?limit=5")
+    assert response.status_code == 200
+    assert mock_repository_factory.preference.get_global.call_count == 1
+    assert mock_repository_factory.lecture.get.call_count == 1
+    assert response.json()["jobs"][0]["link_path"] == "/courses/7/lectures/5"
+
+
+@pytest.mark.unit
+def test_jobs_summary_returns_dashboard_stats(client: TestClient, mock_repository_factory):
+    stats = {
+        "counts": {"done": 5, "failed": 1},
+        "avg_wait_seconds": 2.5,
+        "failed_last_hour": 1,
+        "window_hours": 24,
+        "kinds_recent": [
+            {
+                "kind": "generate_lecture_slide",
+                "count": 4,
+                "avg_duration_ms": 63000.0,
+                "p50_duration_ms": 60000.0,
+            }
+        ],
+    }
+    mock_repository_factory.job.dashboard_stats.return_value = stats
+
+    response = client.get("/api/v1/jobs/summary")
+    assert response.status_code == 200
+    assert response.json() == stats
+    mock_repository_factory.job.dashboard_stats.assert_called_once_with(window_hours=24)
+
+
+@pytest.mark.unit
+def test_jobs_summary_clamps_window(client: TestClient, mock_repository_factory):
+    mock_repository_factory.job.dashboard_stats.return_value = {}
+
+    client.get("/api/v1/jobs/summary?window_hours=9999")
+    mock_repository_factory.job.dashboard_stats.assert_called_once_with(window_hours=168)

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -2,6 +2,8 @@
 Integration tests for the database models and repository.
 """
 
+import uuid
+
 import pytest
 
 from artificial_u.models.core import Course, Department, Faculty, Lecture, Professor, Topic
@@ -532,3 +534,57 @@ def test_tag_repository_faceted_counts(repository, db_department, db_professor):
 
     # A combination with zero matching courses yields no tags at all
     assert tag_repo.list_with_counts(language="en", tags=["military-history", "neurobiology"]) == []
+
+
+@pytest.mark.integration
+def test_job_list_keyset_pagination(repository):
+    """before_id pages through jobs newest-first with no overlap between pages."""
+    job_repo = repository.job
+    # Unique kind keeps the test deterministic on a persistent test database.
+    kind = f"test_keyset_{uuid.uuid4().hex[:8]}"
+    created_ids = [job_repo.create(kind=kind, payload={"n": i}).id for i in range(5)]
+
+    page_one = job_repo.list(kind=kind, limit=3)
+    page_one_ids = [job.id for job in page_one]
+    assert page_one_ids == sorted(created_ids, reverse=True)[:3]
+
+    page_two = job_repo.list(kind=kind, limit=3, before_id=page_one_ids[-1])
+    page_two_ids = [job.id for job in page_two]
+    assert page_two_ids == sorted(created_ids, reverse=True)[3:]
+    assert not set(page_one_ids) & set(page_two_ids)
+
+
+@pytest.mark.integration
+def test_job_dashboard_stats(repository):
+    """dashboard_stats aggregates counts, queue health, and per-kind durations."""
+    job_repo = repository.job
+    done_kind = f"test_stats_done_{uuid.uuid4().hex[:8]}"
+    pending_kind = f"test_stats_pending_{uuid.uuid4().hex[:8]}"
+
+    done_a = job_repo.create(kind=done_kind, payload={})
+    done_b = job_repo.create(kind=done_kind, payload={})
+    job_repo.mark_done(done_a.id, {"_job_telemetry": {"duration_ms": 60000}})
+    job_repo.mark_done(done_b.id, {"_job_telemetry": {"duration_ms": 30000}})
+
+    job_repo.create(kind=pending_kind, payload={})
+    failed = job_repo.create(kind=pending_kind, payload={})
+    job_repo.mark_failed_or_retry(failed.id, attempts=2, max_attempts=2, last_error="boom")
+
+    stats = job_repo.dashboard_stats(window_hours=24)
+
+    assert stats["counts"]["done"] >= 2
+    assert stats["counts"]["queued"] >= 1
+    assert stats["counts"]["failed"] >= 1
+    assert stats["failed_last_hour"] >= 1
+    assert stats["avg_wait_seconds"] >= 0.0
+    assert stats["window_hours"] == 24
+
+    by_kind = {entry["kind"]: entry for entry in stats["kinds_recent"]}
+    done_stats = by_kind[done_kind]
+    assert done_stats["count"] == 2
+    assert done_stats["avg_duration_ms"] == pytest.approx(45000.0)
+    assert done_stats["p50_duration_ms"] == pytest.approx(45000.0)
+    # The queued/failed jobs have no completed telemetry to aggregate.
+    pending_stats = by_kind[pending_kind]
+    assert pending_stats["count"] == 2
+    assert pending_stats["avg_duration_ms"] is None

--- a/web/src/api/services/jobs-service.ts
+++ b/web/src/api/services/jobs-service.ts
@@ -25,6 +25,28 @@ export interface JobRow {
   link_path?: string | null
 }
 
+export interface JobListPage {
+  jobs: JobRow[]
+  has_more: boolean
+  /** Pass as before_id to fetch the next (older) page; null on the last page. */
+  next_before_id: number | null
+}
+
+export interface JobKindStat {
+  kind: string
+  count: number
+  avg_duration_ms: number | null
+  p50_duration_ms: number | null
+}
+
+export interface JobsSummary {
+  counts: Partial<Record<JobStatus, number>>
+  avg_wait_seconds: number
+  failed_last_hour: number
+  window_hours: number
+  kinds_recent: JobKindStat[]
+}
+
 export async function getJob(jobId: number): Promise<JobRow> {
   return httpClient.get<JobRow>(ENDPOINTS.jobs.detail(jobId))
 }
@@ -37,7 +59,8 @@ export async function listJobs(params?: {
   topic_id?: number
   course_id?: number
   parent_id?: number
-}): Promise<JobRow[]> {
+  before_id?: number
+}): Promise<JobListPage> {
   const qs = new URLSearchParams()
   if (params?.status) qs.set('status', params.status)
   if (params?.limit) qs.set('limit', String(params.limit))
@@ -46,8 +69,13 @@ export async function listJobs(params?: {
   if (params?.topic_id != null) qs.set('topic_id', String(params.topic_id))
   if (params?.course_id != null) qs.set('course_id', String(params.course_id))
   if (params?.parent_id != null) qs.set('parent_id', String(params.parent_id))
+  if (params?.before_id != null) qs.set('before_id', String(params.before_id))
   const endpoint = `${ENDPOINTS.jobs.list}${qs.toString() ? `?${qs.toString()}` : ''}`
-  return httpClient.get<JobRow[]>(endpoint)
+  return httpClient.get<JobListPage>(endpoint)
+}
+
+export async function getJobsSummary(): Promise<JobsSummary> {
+  return httpClient.get<JobsSummary>(ENDPOINTS.jobs.summary)
 }
 
 export async function listJobChildren(parentJobId: number): Promise<JobRow[]> {

--- a/web/src/components/jobs/JobCard.tsx
+++ b/web/src/components/jobs/JobCard.tsx
@@ -19,7 +19,7 @@ interface JobCardProps {
   onCancel: (job: JobRow) => void
 }
 
-const STATUS_VARIANT: Record<
+export const STATUS_VARIANT: Record<
   JobRow['status'],
   'info' | 'warning' | 'success' | 'danger' | 'outline'
 > = {

--- a/web/src/components/jobs/JobCard.tsx
+++ b/web/src/components/jobs/JobCard.tsx
@@ -1,0 +1,119 @@
+import { A } from '@solidjs/router'
+import { createMemo, Show } from 'solid-js'
+import type { JobRow } from '../../api/services/jobs-service'
+import { getJobKindLabel } from '../../utils/job-management'
+import { Badge, Button } from '../ui'
+import {
+  durationMsFromResult,
+  formatDurationMs,
+  formatShortRelative,
+  jobParamsText,
+  runningElapsedMs,
+} from './job-feed'
+
+interface JobCardProps {
+  job: JobRow
+  /** Reactive clock (ms) driving relative times and the live running duration. */
+  now: number
+  onShowError: (job: JobRow) => void
+  onCancel: (job: JobRow) => void
+}
+
+const STATUS_VARIANT: Record<
+  JobRow['status'],
+  'info' | 'warning' | 'success' | 'danger' | 'outline'
+> = {
+  queued: 'info',
+  running: 'warning',
+  done: 'success',
+  failed: 'danger',
+  cancelled: 'outline',
+}
+
+export default function JobCard(props: JobCardProps) {
+  const isActive = () => props.job.status === 'queued' || props.job.status === 'running'
+
+  const duration = createMemo(() => {
+    if (props.job.status === 'running') {
+      const elapsed = runningElapsedMs(props.job, props.now)
+      return elapsed != null ? `${formatDurationMs(elapsed)}…` : null
+    }
+    const ms = props.job.duration_ms ?? durationMsFromResult(props.job.result)
+    return ms != null ? formatDurationMs(ms) : null
+  })
+
+  const params = createMemo(() => jobParamsText(props.job))
+  const showAttempts = () =>
+    props.job.attempts > 1 || props.job.status === 'failed' || Boolean(props.job.last_error)
+
+  return (
+    <div class="arcane-card p-4 animate-fade-in">
+      <div class="flex items-center gap-2">
+        <Badge variant={STATUS_VARIANT[props.job.status]}>
+          <Show when={props.job.status === 'running'}>
+            <span class="mr-1.5 inline-block h-1.5 w-1.5 rounded-full bg-current animate-pulse" />
+          </Show>
+          {props.job.status}
+        </Badge>
+        <span class="font-medium text-sm truncate">{getJobKindLabel(props.job.kind)}</span>
+        <span class="text-xs text-muted">#{props.job.id}</span>
+        <span class="ml-auto text-xs text-muted whitespace-nowrap">
+          {formatShortRelative(props.job.created_at, props.now)}
+        </span>
+      </div>
+
+      <div class="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted">
+        <Show when={props.job.model}>
+          <span class="font-mono">{props.job.model}</span>
+        </Show>
+        <Show when={duration()}>
+          <span title="Run time">{duration()}</span>
+        </Show>
+        <Show when={showAttempts()}>
+          <span>
+            attempt {props.job.attempts}/{props.job.max_attempts}
+          </span>
+        </Show>
+      </div>
+
+      <Show when={params() || props.job.last_error || isActive()}>
+        <div class="mt-2 flex items-center gap-2 text-xs">
+          <Show when={params()}>
+            <Show
+              when={props.job.link_path}
+              fallback={<span class="text-muted truncate">{params()}</span>}
+            >
+              <A href={props.job.link_path as string} class="text-accent hover:underline truncate">
+                {params()}
+              </A>
+            </Show>
+          </Show>
+          <Show when={props.job.last_error}>
+            <button
+              type="button"
+              class="text-danger hover:underline cursor-pointer truncate max-w-[40%]"
+              onClick={() => {
+                props.onShowError(props.job)
+              }}
+            >
+              {props.job.last_error}
+            </button>
+          </Show>
+          <Show when={isActive()}>
+            <span class="ml-auto">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  props.onCancel(props.job)
+                }}
+              >
+                Cancel
+              </Button>
+            </span>
+          </Show>
+        </div>
+      </Show>
+    </div>
+  )
+}

--- a/web/src/components/jobs/JobErrorModal.tsx
+++ b/web/src/components/jobs/JobErrorModal.tsx
@@ -1,6 +1,12 @@
-import { Show } from 'solid-js'
+import * as Dialog from '@kobalte/core/dialog'
+import { A } from '@solidjs/router'
+import { createSignal, onCleanup, Show } from 'solid-js'
 import type { JobRow } from '../../api/services/jobs-service'
-import { Button } from '../ui'
+import { formatLocalDateTimeISO } from '../../utils/formatDate'
+import { getJobKindLabel } from '../../utils/job-management'
+import { Badge, Button } from '../ui'
+import { STATUS_VARIANT } from './JobCard'
+import { durationMsFromResult, formatDurationMs, jobParamsText } from './job-feed'
 
 interface JobErrorModalProps {
   job: JobRow | null
@@ -8,53 +14,121 @@ interface JobErrorModalProps {
 }
 
 export default function JobErrorModal(props: JobErrorModalProps) {
+  const [copied, setCopied] = createSignal(false)
+  let copiedTimer: ReturnType<typeof setTimeout> | null = null
+  onCleanup(() => {
+    if (copiedTimer) clearTimeout(copiedTimer)
+  })
+
+  const copyError = (text: string) => {
+    void navigator.clipboard.writeText(text).then(() => {
+      setCopied(true)
+      if (copiedTimer) clearTimeout(copiedTimer)
+      copiedTimer = setTimeout(() => {
+        setCopied(false)
+      }, 1500)
+    })
+  }
+
+  const handleOpenChange = (isOpen: boolean) => {
+    if (!isOpen) props.onClose()
+  }
+
   return (
-    <Show when={props.job}>
-      {(job) => (
-        <div
-          class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-          onClick={() => {
-            props.onClose()
-          }}
-        >
-          <div
-            class="arcane-card max-w-3xl max-h-[80vh] w-full mx-4 overflow-hidden flex flex-col"
-            onClick={(e) => {
-              e.stopPropagation()
+    <Dialog.Root open={props.job !== null} onOpenChange={handleOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay class="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm" />
+        <div class="fixed inset-0 z-50 flex items-center justify-center p-4">
+          <Show when={props.job}>
+            {(job) => {
+              const durationMs = () => job().duration_ms ?? durationMsFromResult(job().result)
+              const params = () => jobParamsText(job())
+              return (
+                <Dialog.Content class="arcane-card max-w-2xl max-h-[85vh] w-full flex flex-col shadow-xl rounded-lg overflow-hidden">
+                  <div class="p-4 sm:p-6 border-b border-border">
+                    <div class="flex items-center gap-2 min-w-0">
+                      <Badge variant={STATUS_VARIANT[job().status]}>{job().status}</Badge>
+                      <Dialog.Title class="text-lg font-display truncate">
+                        {getJobKindLabel(job().kind)}
+                      </Dialog.Title>
+                      <span class="text-sm text-muted whitespace-nowrap">#{job().id}</span>
+                      <span class="ml-auto">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => {
+                            props.onClose()
+                          }}
+                        >
+                          ✕
+                        </Button>
+                      </span>
+                    </div>
+                    <div class="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted">
+                      <Show when={job().model}>
+                        <span class="font-mono">{job().model}</span>
+                      </Show>
+                      <span>
+                        attempt {job().attempts}/{job().max_attempts}
+                      </span>
+                      <Show when={durationMs() != null}>
+                        <span title="Run time">{formatDurationMs(durationMs())}</span>
+                      </Show>
+                      <Show when={job().updated_at}>
+                        <span title="Last update">
+                          {formatLocalDateTimeISO(job().updated_at as string)}
+                        </span>
+                      </Show>
+                    </div>
+                    <Show when={params()}>
+                      <div class="mt-1.5 text-xs">
+                        <Show
+                          when={job().link_path}
+                          fallback={<span class="text-muted">{params()}</span>}
+                        >
+                          <A href={job().link_path as string} class="text-accent hover:underline">
+                            {params()} →
+                          </A>
+                        </Show>
+                      </div>
+                    </Show>
+                  </div>
+                  <Dialog.Description
+                    as="div"
+                    class="p-4 sm:p-6 overflow-auto flex-1 min-h-0 text-left"
+                  >
+                    <div class="bg-danger-bg border border-danger-border rounded-sm p-4 overflow-x-auto">
+                      <pre class="text-xs font-mono whitespace-pre-wrap break-words">
+                        {job().last_error || 'No error message available'}
+                      </pre>
+                    </div>
+                  </Dialog.Description>
+                  <div class="flex justify-end gap-2 p-4 sm:p-6 border-t border-border">
+                    <Show when={job().last_error}>
+                      <Button
+                        variant="outline"
+                        onClick={() => {
+                          copyError(job().last_error as string)
+                        }}
+                      >
+                        {copied() ? 'Copied ✓' : 'Copy error'}
+                      </Button>
+                    </Show>
+                    <Button
+                      variant="secondary"
+                      onClick={() => {
+                        props.onClose()
+                      }}
+                    >
+                      Close
+                    </Button>
+                  </div>
+                </Dialog.Content>
+              )
             }}
-          >
-            <div class="flex items-center justify-between p-4 sm:p-6 border-b border-border">
-              <h2 class="text-xl font-display">
-                Job Error - {job().kind} #{job().id}
-              </h2>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => {
-                  props.onClose()
-                }}
-              >
-                ✕
-              </Button>
-            </div>
-            <div class="p-4 sm:p-6 overflow-auto">
-              <pre class="text-xs font-mono bg-muted/50 p-4 rounded overflow-x-auto whitespace-pre-wrap break-words">
-                {job().last_error || 'No error message available'}
-              </pre>
-            </div>
-            <div class="flex justify-end gap-2 p-4 sm:p-6 border-t border-border">
-              <Button
-                variant="secondary"
-                onClick={() => {
-                  props.onClose()
-                }}
-              >
-                Close
-              </Button>
-            </div>
-          </div>
+          </Show>
         </div>
-      )}
-    </Show>
+      </Dialog.Portal>
+    </Dialog.Root>
   )
 }

--- a/web/src/components/jobs/JobErrorModal.tsx
+++ b/web/src/components/jobs/JobErrorModal.tsx
@@ -1,0 +1,60 @@
+import { Show } from 'solid-js'
+import type { JobRow } from '../../api/services/jobs-service'
+import { Button } from '../ui'
+
+interface JobErrorModalProps {
+  job: JobRow | null
+  onClose: () => void
+}
+
+export default function JobErrorModal(props: JobErrorModalProps) {
+  return (
+    <Show when={props.job}>
+      {(job) => (
+        <div
+          class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          onClick={() => {
+            props.onClose()
+          }}
+        >
+          <div
+            class="arcane-card max-w-3xl max-h-[80vh] w-full mx-4 overflow-hidden flex flex-col"
+            onClick={(e) => {
+              e.stopPropagation()
+            }}
+          >
+            <div class="flex items-center justify-between p-4 sm:p-6 border-b border-border">
+              <h2 class="text-xl font-display">
+                Job Error - {job().kind} #{job().id}
+              </h2>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  props.onClose()
+                }}
+              >
+                ✕
+              </Button>
+            </div>
+            <div class="p-4 sm:p-6 overflow-auto">
+              <pre class="text-xs font-mono bg-muted/50 p-4 rounded overflow-x-auto whitespace-pre-wrap break-words">
+                {job().last_error || 'No error message available'}
+              </pre>
+            </div>
+            <div class="flex justify-end gap-2 p-4 sm:p-6 border-t border-border">
+              <Button
+                variant="secondary"
+                onClick={() => {
+                  props.onClose()
+                }}
+              >
+                Close
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </Show>
+  )
+}

--- a/web/src/components/jobs/JobFilters.tsx
+++ b/web/src/components/jobs/JobFilters.tsx
@@ -1,0 +1,52 @@
+import { createMemo, Show } from 'solid-js'
+import type { JobKindStat } from '../../api/services/jobs-service'
+import { getJobKindLabel, JOB_KINDS } from '../../utils/job-management'
+import { Select } from '../ui'
+import { formatDurationMs } from './job-feed'
+
+interface JobFiltersProps {
+  kind: string | undefined
+  onKindChange: (kind: string | undefined) => void
+  kindStats: JobKindStat[] | undefined
+}
+
+const ALL_KINDS = ''
+
+/**
+ * Kind filter with recent per-kind stats for the selected kind — the numbers
+ * used to estimate how long a currently running job will take.
+ */
+export default function JobFilters(props: JobFiltersProps) {
+  const options = createMemo(() => [
+    { value: ALL_KINDS, label: 'All kinds' },
+    ...JOB_KINDS.map((kind) => ({ value: kind, label: getJobKindLabel(kind) })),
+  ])
+
+  const selectedStat = createMemo(() => {
+    if (!props.kind) return undefined
+    return props.kindStats?.find((stat) => stat.kind === props.kind)
+  })
+
+  return (
+    <div class="mb-4">
+      <Select
+        name="job-kind-filter"
+        label="Filter by job kind"
+        options={options()}
+        value={props.kind ?? ALL_KINDS}
+        onChange={(value) => {
+          props.onKindChange(value ? String(value) : undefined)
+        }}
+        placeholder="All kinds"
+      />
+      <Show when={selectedStat()}>
+        {(stat) => (
+          <div class="mt-1.5 text-xs text-muted">
+            Last 24h: {stat().count} jobs · avg {formatDurationMs(stat().avg_duration_ms)} · p50{' '}
+            {formatDurationMs(stat().p50_duration_ms)}
+          </div>
+        )}
+      </Show>
+    </div>
+  )
+}

--- a/web/src/components/jobs/JobStatStrip.tsx
+++ b/web/src/components/jobs/JobStatStrip.tsx
@@ -1,0 +1,72 @@
+import { For, Show } from 'solid-js'
+import type { JobStatus, JobsSummary } from '../../api/services/jobs-service'
+
+interface JobStatStripProps {
+  summary: JobsSummary | undefined
+  activeStatus: JobStatus | undefined
+  onToggleStatus: (status: JobStatus) => void
+}
+
+const STATUSES: Array<{ status: JobStatus; label: string; accent: string }> = [
+  { status: 'queued', label: 'Queued', accent: 'text-info' },
+  { status: 'running', label: 'Running', accent: 'text-warning' },
+  { status: 'done', label: 'Done', accent: 'text-success' },
+  { status: 'failed', label: 'Failed', accent: 'text-danger' },
+  { status: 'cancelled', label: 'Cancelled', accent: 'text-muted' },
+]
+
+function formatWaitSeconds(seconds: number | undefined): string {
+  if (seconds == null) return '-'
+  if (seconds < 90) return `${String(Math.round(seconds))}s`
+  return `${String(Math.round(seconds / 60))}m`
+}
+
+/**
+ * Counts-by-status tiles that double as the status filter, plus a small
+ * queue-health line (failures in the last hour, average queued wait).
+ */
+export default function JobStatStrip(props: JobStatStripProps) {
+  return (
+    <div class="mb-4">
+      <div class="grid grid-cols-3 sm:grid-cols-5 gap-2">
+        <For each={STATUSES}>
+          {(entry) => (
+            <button
+              type="button"
+              onClick={() => {
+                props.onToggleStatus(entry.status)
+              }}
+              class="arcane-card p-3 text-center cursor-pointer transition-all"
+              classList={{
+                'ring-2 ring-primary': props.activeStatus === entry.status,
+                'opacity-60':
+                  props.activeStatus !== undefined && props.activeStatus !== entry.status,
+              }}
+              aria-pressed={props.activeStatus === entry.status}
+            >
+              <div class={`stat-number-sm ${entry.accent}`}>
+                {props.summary?.counts[entry.status] ?? 0}
+              </div>
+              <div class="section-label mt-1">{entry.label}</div>
+            </button>
+          )}
+        </For>
+      </div>
+      <Show when={props.summary}>
+        {(summary) => (
+          <div class="mt-2 text-xs text-muted flex gap-4">
+            <span
+              classList={{ 'text-danger': summary().failed_last_hour > 0 }}
+              title="Jobs that failed in the last hour"
+            >
+              Failed 1h: {summary().failed_last_hour}
+            </span>
+            <span title="Average wait of currently queued jobs">
+              Avg wait: {formatWaitSeconds(summary().avg_wait_seconds)}
+            </span>
+          </div>
+        )}
+      </Show>
+    </div>
+  )
+}

--- a/web/src/components/jobs/job-feed.test.ts
+++ b/web/src/components/jobs/job-feed.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest'
+import type { JobEvent, JobRow } from '../../api/services/jobs-service'
+import {
+  appendPage,
+  applyJobEvent,
+  applySnapshot,
+  formatDurationMs,
+  formatShortRelative,
+  jobParamsText,
+  matchesFilters,
+  runningElapsedMs,
+} from './job-feed'
+
+function row(id: number, overrides: Partial<JobRow> = {}): JobRow {
+  return {
+    id,
+    kind: 'generate_lecture_slide',
+    status: 'queued',
+    attempts: 1,
+    max_attempts: 2,
+    ...overrides,
+  }
+}
+
+function event(id: number, overrides: Partial<JobEvent> = {}): JobEvent {
+  return { id, kind: 'generate_lecture_slide', status: 'running', ...overrides }
+}
+
+describe('applyJobEvent', () => {
+  it('patches a known job in place without refetching', () => {
+    const jobs = [row(1), row(2)]
+    const { jobs: next, needsHydration } = applyJobEvent(jobs, event(2), {})
+    expect(needsHydration).toBeNull()
+    expect(next[1].status).toBe('running')
+    expect(next[0]).toBe(jobs[0]) // untouched rows keep identity
+  })
+
+  it('keeps a card whose new status no longer matches the status filter', () => {
+    const jobs = [row(1, { status: 'running' })]
+    const { jobs: next } = applyJobEvent(jobs, event(1, { status: 'done' }), {
+      status: 'running',
+    })
+    expect(next).toHaveLength(1)
+    expect(next[0].status).toBe('done')
+  })
+
+  it('extracts duration telemetry from a terminal event result', () => {
+    const jobs = [row(1, { status: 'running' })]
+    const { jobs: next } = applyJobEvent(
+      jobs,
+      event(1, { status: 'done', result: { _job_telemetry: { duration_ms: 63000 } } }),
+      {}
+    )
+    expect(next[0].duration_ms).toBe(63000)
+  })
+
+  it('prepends an unknown matching job and requests hydration', () => {
+    const jobs = [row(1)]
+    const { jobs: next, needsHydration } = applyJobEvent(jobs, event(99), {})
+    expect(needsHydration).toBe(99)
+    expect(next[0].id).toBe(99)
+    expect(next).toHaveLength(2)
+  })
+
+  it('ignores an unknown job that does not match the filters', () => {
+    const jobs = [row(1)]
+    const kindMismatch = applyJobEvent(jobs, event(99), { kind: 'generate_lecture_audio' })
+    expect(kindMismatch.jobs).toBe(jobs)
+    expect(kindMismatch.needsHydration).toBeNull()
+
+    const statusMismatch = applyJobEvent(jobs, event(99, { status: 'running' }), {
+      status: 'failed',
+    })
+    expect(statusMismatch.jobs).toBe(jobs)
+  })
+
+  it('caps the feed length', () => {
+    const jobs = [row(1), row(2), row(3)]
+    const { jobs: next } = applyJobEvent(jobs, event(99), {}, 3)
+    expect(next).toHaveLength(3)
+    expect(next[0].id).toBe(99)
+    expect(next[2].id).toBe(2)
+  })
+})
+
+describe('applySnapshot', () => {
+  it('patches known jobs and prepends unknown matching rows, newest first', () => {
+    const jobs = [row(5), row(3)]
+    const snapshot = [row(3, { status: 'running' }), row(8), row(10)]
+    const next = applySnapshot(jobs, snapshot, {})
+    expect(next.map((job) => job.id)).toEqual([10, 8, 5, 3])
+    expect(next.find((job) => job.id === 3)?.status).toBe('running')
+  })
+
+  it('never clears the list and respects filters for new rows', () => {
+    const jobs = [row(5)]
+    const next = applySnapshot(jobs, [row(8, { kind: 'generate_lecture_audio' })], {
+      kind: 'generate_lecture_slide',
+    })
+    expect(next.map((job) => job.id)).toEqual([5])
+  })
+})
+
+describe('appendPage', () => {
+  it('appends older rows and drops duplicates already in the feed', () => {
+    const jobs = [row(10), row(9)]
+    const next = appendPage(jobs, [row(9), row(8)])
+    expect(next.map((job) => job.id)).toEqual([10, 9, 8])
+  })
+})
+
+describe('matchesFilters', () => {
+  it('matches on both status and kind when set', () => {
+    expect(matchesFilters(row(1), {})).toBe(true)
+    expect(matchesFilters(row(1), { status: 'queued' })).toBe(true)
+    expect(matchesFilters(row(1), { status: 'done' })).toBe(false)
+    expect(matchesFilters(row(1), { kind: 'generate_lecture_slide' })).toBe(true)
+    expect(matchesFilters(row(1), { kind: 'other' })).toBe(false)
+  })
+})
+
+describe('jobParamsText', () => {
+  it('reads ids from payload and partial_attributes', () => {
+    expect(jobParamsText(row(1, { payload: { lecture_id: 482, topic_id: 1778 } }))).toBe(
+      'lecture 482 · topic 1778'
+    )
+    expect(jobParamsText(row(1, { payload: { partial_attributes: { course_id: 7 } } }))).toBe(
+      'course 7'
+    )
+    expect(jobParamsText(row(1))).toBe('')
+  })
+})
+
+describe('formatting helpers', () => {
+  it('formats short relative times', () => {
+    const now = Date.parse('2026-07-22T12:00:00Z')
+    expect(formatShortRelative('2026-07-22T11:59:30Z', now)).toBe('30s')
+    expect(formatShortRelative('2026-07-22T11:30:00Z', now)).toBe('30m')
+    expect(formatShortRelative('2026-07-21T12:00:00Z', now)).toBe('24h')
+    expect(formatShortRelative(undefined, now)).toBe('-')
+  })
+
+  it('formats durations', () => {
+    expect(formatDurationMs(63000)).toBe('63s')
+    expect(formatDurationMs(185000)).toBe('3m 05s')
+    expect(formatDurationMs(null)).toBe('-')
+  })
+
+  it('computes plausible running elapsed time only', () => {
+    const now = Date.parse('2026-07-22T12:00:00Z')
+    const running = row(1, { status: 'running', updated_at: '2026-07-22T11:59:00Z' })
+    expect(runningElapsedMs(running, now)).toBe(60000)
+    const stale = row(1, { status: 'running', updated_at: '2026-07-19T11:59:00Z' })
+    expect(runningElapsedMs(stale, now)).toBeNull()
+    expect(runningElapsedMs(row(1, { status: 'running' }), now)).toBeNull()
+  })
+})

--- a/web/src/components/jobs/job-feed.ts
+++ b/web/src/components/jobs/job-feed.ts
@@ -1,0 +1,195 @@
+/**
+ * Pure helpers for the admin jobs dashboard feed.
+ *
+ * The feed is updated in place from SSE events — never by refetching the whole
+ * list — so these functions take the current array and return a new one.
+ */
+
+import type { JobEvent, JobRow } from '../../api/services/jobs-service'
+
+export interface JobFeedFilters {
+  status?: JobRow['status']
+  kind?: string
+}
+
+export const FEED_CAP = 200
+
+export function durationMsFromResult(result: unknown): number | null {
+  if (!result || typeof result !== 'object') return null
+  const o = result as { _job_telemetry?: { duration_ms?: number } }
+  const ms = o._job_telemetry?.duration_ms
+  return typeof ms === 'number' && !Number.isNaN(ms) ? ms : null
+}
+
+export function matchesFilters(
+  job: Pick<JobRow, 'kind' | 'status'>,
+  filters: JobFeedFilters
+): boolean {
+  if (filters.status && job.status !== filters.status) return false
+  if (filters.kind && job.kind !== filters.kind) return false
+  return true
+}
+
+/** Minimal placeholder row for a job first seen via SSE; hydrated by a getJob fetch. */
+export function provisionalRowFromEvent(event: JobEvent): JobRow {
+  const nowIso = new Date().toISOString()
+  return {
+    id: event.id,
+    kind: event.kind,
+    status: event.status,
+    attempts: 1,
+    max_attempts: 1,
+    payload: event.payload,
+    result: event.result,
+    last_error: event.last_error ?? null,
+    duration_ms: durationMsFromResult(event.result),
+    created_at: nowIso,
+    updated_at: nowIso,
+  }
+}
+
+function patchedRow(row: JobRow, event: JobEvent): JobRow {
+  const eventDuration = event.result !== undefined ? durationMsFromResult(event.result) : null
+  return {
+    ...row,
+    status: event.status,
+    last_error: event.last_error || row.last_error,
+    result: event.result !== undefined ? event.result : row.result,
+    duration_ms: eventDuration ?? row.duration_ms,
+    updated_at: new Date().toISOString(),
+  }
+}
+
+export interface ApplyJobEventResult {
+  jobs: JobRow[]
+  /** Job id to fetch fully (a job first seen via SSE), or null. */
+  needsHydration: number | null
+}
+
+/**
+ * Fold one SSE event into the feed.
+ *
+ * Known jobs are patched in place and deliberately kept even when their new
+ * status no longer matches the active filter — watching a card transition
+ * queued -> running -> done is the point of the page. Unknown jobs are
+ * prepended (as provisional rows) only when they match the filters.
+ */
+export function applyJobEvent(
+  jobs: JobRow[],
+  event: JobEvent,
+  filters: JobFeedFilters,
+  cap: number = FEED_CAP
+): ApplyJobEventResult {
+  const index = jobs.findIndex((job) => job.id === event.id)
+  if (index !== -1) {
+    const next = [...jobs]
+    next[index] = patchedRow(jobs[index], event)
+    return { jobs: next, needsHydration: null }
+  }
+
+  if (!matchesFilters(event, filters)) {
+    return { jobs, needsHydration: null }
+  }
+
+  const next = [provisionalRowFromEvent(event), ...jobs].slice(0, cap)
+  return { jobs: next, needsHydration: event.id }
+}
+
+/**
+ * Fold an SSE snapshot (full server rows for active jobs) into the feed.
+ * Patches known jobs and prepends unknown matching ones; never clears the list.
+ */
+export function applySnapshot(
+  jobs: JobRow[],
+  snapshot: Array<JobEvent | JobRow>,
+  filters: JobFeedFilters,
+  cap: number = FEED_CAP
+): JobRow[] {
+  let next = [...jobs]
+  const toPrepend: JobRow[] = []
+
+  for (const item of snapshot) {
+    const index = next.findIndex((job) => job.id === item.id)
+    if (index !== -1) {
+      next[index] = { ...next[index], ...item }
+      continue
+    }
+    if (!matchesFilters(item, filters)) continue
+    const full = 'attempts' in item ? item : provisionalRowFromEvent(item)
+    toPrepend.push(full)
+  }
+
+  if (toPrepend.length > 0) {
+    // Newest first, consistent with the feed ordering.
+    toPrepend.sort((a, b) => b.id - a.id)
+    next = [...toPrepend, ...next]
+  }
+  return next.slice(0, cap)
+}
+
+/** Append an older page from the API, dropping any rows already in the feed. */
+export function appendPage(jobs: JobRow[], page: JobRow[]): JobRow[] {
+  const known = new Set(jobs.map((job) => job.id))
+  return [...jobs, ...page.filter((job) => !known.has(job.id))]
+}
+
+/** Entity references from a job payload, e.g. "lecture 482 · topic 1778". */
+export function jobParamsText(job: JobRow): string {
+  const payload = (job.payload ?? {}) as Record<string, unknown>
+  const partial = (payload.partial_attributes ?? {}) as Record<string, unknown>
+
+  const pick = (key: string): string | null => {
+    for (const source of [payload, partial]) {
+      const value = source[key]
+      if (typeof value === 'string' || typeof value === 'number') return String(value)
+    }
+    return null
+  }
+
+  const parts: string[] = []
+  const lectureId = pick('lecture_id')
+  if (lectureId) parts.push(`lecture ${lectureId}`)
+  const topicId = pick('topic_id')
+  if (topicId) parts.push(`topic ${topicId}`)
+  const courseId = pick('course_id')
+  if (courseId) parts.push(`course ${courseId}`)
+  return parts.join(' · ')
+}
+
+/** Compact relative time: "12s", "3m", "2h", "5d". */
+export function formatShortRelative(iso: string | undefined, nowMs: number): string {
+  if (!iso) return '-'
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return '-'
+  const sec = Math.max(0, Math.round((nowMs - then) / 1000))
+  if (sec < 60) return `${String(sec)}s`
+  const min = Math.floor(sec / 60)
+  if (min < 60) return `${String(min)}m`
+  const hours = Math.floor(min / 60)
+  if (hours < 48) return `${String(hours)}h`
+  return `${String(Math.floor(hours / 24))}d`
+}
+
+/** Duration in whole seconds ("63s") or minutes+seconds ("2m 05s"). */
+export function formatDurationMs(ms: number | null | undefined): string {
+  if (ms == null || Number.isNaN(ms)) return '-'
+  const sec = Math.round(ms / 1000)
+  if (sec < 120) return `${String(sec)}s`
+  const min = Math.floor(sec / 60)
+  const rest = sec % 60
+  return `${String(min)}m ${String(rest).padStart(2, '0')}s`
+}
+
+/**
+ * Live elapsed time for a running job, from its last transition to running.
+ * Returns null when the timestamp is missing or implausible (e.g. clock skew).
+ */
+export function runningElapsedMs(job: JobRow, nowMs: number): number | null {
+  const since = job.updated_at ?? job.created_at
+  if (!since) return null
+  const then = new Date(since).getTime()
+  if (Number.isNaN(then)) return null
+  const elapsed = nowMs - then
+  if (elapsed < 0 || elapsed > 24 * 60 * 60 * 1000) return null
+  return elapsed
+}

--- a/web/src/components/ui/Badge.tsx
+++ b/web/src/components/ui/Badge.tsx
@@ -1,6 +1,6 @@
 import { type JSX, splitProps } from 'solid-js'
 
-type BadgeVariant = 'default' | 'outline' | 'secondary' | 'success' | 'danger'
+type BadgeVariant = 'default' | 'outline' | 'secondary' | 'success' | 'danger' | 'warning' | 'info'
 
 interface BadgeProps {
   variant?: BadgeVariant
@@ -17,6 +17,8 @@ export function Badge(props: BadgeProps) {
     secondary: 'bg-accent/40 text-accent',
     success: 'bg-success-bg text-success',
     danger: 'bg-danger-bg text-danger',
+    warning: 'bg-warning-bg text-warning',
+    info: 'bg-info-bg text-info',
   }
 
   return (

--- a/web/src/pages/Jobs.tsx
+++ b/web/src/pages/Jobs.tsx
@@ -1,420 +1,282 @@
-import { A } from '@solidjs/router'
-import { createResource, createSignal, For, onCleanup, Show } from 'solid-js'
+import {
+  batch,
+  createEffect,
+  createMemo,
+  createResource,
+  createSignal,
+  For,
+  onCleanup,
+  Show,
+  untrack,
+} from 'solid-js'
 import {
   cancelJob,
+  getJob,
+  getJobsSummary,
   type JobEvent,
   type JobRow,
   type JobStatus,
   listJobs,
 } from '../api/services/jobs-service'
-import { Button } from '../components/ui'
-import { formatLocalDateTimeISO } from '../utils/formatDate'
+import JobCard from '../components/jobs/JobCard'
+import JobErrorModal from '../components/jobs/JobErrorModal'
+import JobFilters from '../components/jobs/JobFilters'
+import JobStatStrip from '../components/jobs/JobStatStrip'
+import { appendPage, applyJobEvent, applySnapshot } from '../components/jobs/job-feed'
+import { Alert, Button, ConfirmationModal } from '../components/ui'
 import { getJobEventHub } from '../utils/job-events-hub'
 
-const STATUS_STYLES: Record<JobStatus, string> = {
-  queued: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-200',
-  running: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-200',
-  done: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-200',
-  failed: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-200',
-  cancelled: 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-200',
-}
+const PAGE_SIZE = 25
 
-function durationMsFromResult(r: unknown): number | null {
-  if (!r || typeof r !== 'object') return null
-  const o = r as { _job_telemetry?: { duration_ms?: number } }
-  const ms = o._job_telemetry?.duration_ms
-  return typeof ms === 'number' && !Number.isNaN(ms) ? ms : null
-}
-
-/** Display whole seconds for readability (from duration_ms). */
-function formatRunDurationSeconds(ms: number | null | undefined): string {
-  if (ms == null) return '-'
-  const sec = Math.round(ms / 1000)
-  return `${String(sec)}s`
-}
-
+/**
+ * Admin jobs dashboard: stat strip (tappable status filters), kind filter, and
+ * a live card feed. The feed is patched in place from SSE events — it is never
+ * wholesale refetched while you're looking at it.
+ */
 export default function JobsPage() {
   const [statusFilter, setStatusFilter] = createSignal<JobStatus | undefined>(undefined)
-  const [cancellingJobId, setCancellingJobId] = createSignal<number | null>(null)
+  const [kindFilter, setKindFilter] = createSignal<string | undefined>(undefined)
+  const [jobs, setJobs] = createSignal<JobRow[]>([])
+  const [loading, setLoading] = createSignal(true)
+  const [loadingMore, setLoadingMore] = createSignal(false)
+  const [loadError, setLoadError] = createSignal<string | null>(null)
+  const [hasMore, setHasMore] = createSignal(false)
+  const [nextBeforeId, setNextBeforeId] = createSignal<number | null>(null)
+  const [now, setNow] = createSignal(Date.now())
   const [errorModalJob, setErrorModalJob] = createSignal<JobRow | null>(null)
+  const [cancelTarget, setCancelTarget] = createSignal<JobRow | null>(null)
+  const [cancelling, setCancelling] = createSignal(false)
+  const [actionError, setActionError] = createSignal<string | null>(null)
 
-  const [jobsResource, { refetch, mutate }] = createResource(
-    () => ({
-      status: statusFilter(),
-      limit: 100,
-    }),
-    listJobs
-  )
+  const filters = () => ({ status: statusFilter(), kind: kindFilter() })
 
-  // Subscribe to SSE updates for real-time job status
+  const [summary, { refetch: refetchSummary }] = createResource(getJobsSummary)
+
+  let loadRunId = 0
+  const loadInitial = async () => {
+    const runId = ++loadRunId
+    setLoading(true)
+    setLoadError(null)
+    try {
+      const page = await listJobs({ ...filters(), limit: PAGE_SIZE })
+      if (runId !== loadRunId) return
+      batch(() => {
+        setJobs(page.jobs)
+        setHasMore(page.has_more)
+        setNextBeforeId(page.next_before_id)
+      })
+    } catch (error) {
+      if (runId !== loadRunId) return
+      setLoadError(error instanceof Error ? error.message : 'Failed to load jobs')
+    } finally {
+      if (runId === loadRunId) setLoading(false)
+    }
+  }
+
+  const loadMore = async () => {
+    const beforeId = nextBeforeId()
+    if (beforeId == null || loadingMore()) return
+    setLoadingMore(true)
+    try {
+      const page = await listJobs({ ...filters(), limit: PAGE_SIZE, before_id: beforeId })
+      batch(() => {
+        setJobs((current) => appendPage(current, page.jobs))
+        setHasMore(page.has_more)
+        setNextBeforeId(page.next_before_id)
+      })
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : 'Failed to load more jobs')
+    } finally {
+      setLoadingMore(false)
+    }
+  }
+
+  // Initial load + reload whenever a filter changes.
+  createEffect(() => {
+    filters()
+    void loadInitial()
+  })
+
+  // Debounced summary refresh after job churn (new jobs or terminal transitions).
+  let summaryTimer: ReturnType<typeof setTimeout> | null = null
+  const scheduleSummaryRefresh = () => {
+    if (summaryTimer) clearTimeout(summaryTimer)
+    summaryTimer = setTimeout(() => {
+      summaryTimer = null
+      void refetchSummary()
+    }, 3000)
+  }
+
+  // Hydrate provisional rows (jobs first seen via SSE) with one getJob fetch.
+  const pendingHydration = new Set<number>()
+  const hydrate = (jobId: number) => {
+    if (pendingHydration.has(jobId)) return
+    pendingHydration.add(jobId)
+    getJob(jobId)
+      .then((row) => {
+        setJobs((current) =>
+          current.map((job) => (job.id === row.id ? { ...row, status: job.status } : job))
+        )
+      })
+      .catch(() => {
+        // Provisional card simply stays sparse; nothing to do.
+      })
+      .finally(() => {
+        pendingHydration.delete(jobId)
+      })
+  }
+
   const hub = getJobEventHub()
-  const unsubscribe = hub.subscribe({}, (event: JobEvent) => {
-    // Update the job in the list when we receive an event
-    mutate((jobs) => {
-      if (!jobs) return jobs
+  const unsubscribe = hub.subscribe(
+    {},
+    (event: JobEvent) => {
+      const result = applyJobEvent(untrack(jobs), event, untrack(filters))
+      setJobs(result.jobs)
+      if (result.needsHydration != null) hydrate(result.needsHydration)
+      if (event.status !== 'running') scheduleSummaryRefresh()
+    },
+    (snapshot) => {
+      setJobs((current) => applySnapshot(current, snapshot, untrack(filters)))
+    }
+  )
+  onCleanup(() => {
+    unsubscribe()
+    if (summaryTimer) clearTimeout(summaryTimer)
+  })
 
-      const jobIndex = jobs.findIndex((j) => j.id === event.id)
-
-      if (jobIndex === -1) {
-        // New job - refetch to get it
-        void refetch()
-        return jobs
-      }
-
-      // Update existing job
-      const updatedJobs = [...jobs]
-      const fromEvent = event.result != null ? durationMsFromResult(event.result) : null
-      updatedJobs[jobIndex] = {
-        ...updatedJobs[jobIndex],
-        status: event.status,
-        last_error: event.last_error || updatedJobs[jobIndex].last_error,
-        result: event.result !== undefined ? event.result : updatedJobs[jobIndex].result,
-        duration_ms: fromEvent != null ? fromEvent : updatedJobs[jobIndex].duration_ms,
-      }
-
-      return updatedJobs
+  // Tick a shared clock while anything is running (live elapsed times).
+  const hasRunning = createMemo(() => jobs().some((job) => job.status === 'running'))
+  createEffect(() => {
+    if (!hasRunning()) return
+    const timer = setInterval(() => setNow(Date.now()), 1000)
+    onCleanup(() => {
+      clearInterval(timer)
     })
   })
 
-  onCleanup(() => {
-    unsubscribe()
-  })
-
-  const handleStatusFilter = (status: JobStatus | undefined) => {
-    setStatusFilter(status)
+  const toggleStatus = (status: JobStatus) => {
+    setStatusFilter((current) => (current === status ? undefined : status))
   }
 
-  const extractParams = (job: JobRow): string => {
-    const payload = job.payload as Record<string, unknown> | undefined
-    if (!payload) return '-'
-
-    const params: string[] = []
-
-    const safeString = (value: unknown): string | null => {
-      if (value === null || value === undefined) return null
-      if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-        return String(value)
-      }
-      return null
-    }
-
-    const lectureId = safeString(payload.lecture_id)
-    if (lectureId) {
-      params.push(`lecture: ${lectureId}`)
-    }
-
-    const topicId = safeString(payload.topic_id)
-    if (topicId) {
-      params.push(`topic: ${topicId}`)
-    } else if (payload.partial_attributes && typeof payload.partial_attributes === 'object') {
-      const partialAttrs = payload.partial_attributes as Record<string, unknown>
-      const partialTopicId = safeString(partialAttrs.topic_id)
-      if (partialTopicId) {
-        params.push(`topic: ${partialTopicId}`)
-      }
-    }
-
-    const courseId = safeString(payload.course_id)
-    if (courseId) {
-      params.push(`course: ${courseId}`)
-    } else if (payload.partial_attributes && typeof payload.partial_attributes === 'object') {
-      const partialAttrs = payload.partial_attributes as Record<string, unknown>
-      const partialCourseId = safeString(partialAttrs.course_id)
-      if (partialCourseId) {
-        params.push(`course: ${partialCourseId}`)
-      }
-    }
-
-    return params.length > 0 ? params.join(', ') : '-'
-  }
-
-  const handleCancelJob = async (jobId: number) => {
-    if (!confirm('Are you sure you want to cancel this job?')) {
-      return
-    }
-
-    setCancellingJobId(jobId)
+  const confirmCancel = async () => {
+    const target = cancelTarget()
+    if (!target) return
+    setCancelling(true)
     try {
-      await cancelJob(jobId)
-      void refetch() // Refresh the job list
+      await cancelJob(target.id)
+      setJobs((current) =>
+        current.map((job) => (job.id === target.id ? { ...job, status: 'cancelled' } : job))
+      )
+      setCancelTarget(null)
+      scheduleSummaryRefresh()
     } catch (error) {
-      console.error('Failed to cancel job:', error)
-      alert('Failed to cancel job. Please try again.')
+      setActionError(error instanceof Error ? error.message : 'Failed to cancel job')
+      setCancelTarget(null)
     } finally {
-      setCancellingJobId(null)
+      setCancelling(false)
     }
   }
 
   return (
     <main class="container mx-auto p-4">
-      <div class="flex justify-between items-center mb-6">
-        <h1 class="text-3xl font-display mb-6 text-parchment-100 text-shadow-golden">
-          Background Jobs
-        </h1>
-        <Button variant="secondary" onClick={() => void refetch()}>
+      <div class="flex items-center justify-between mb-4">
+        <h2 class="text-xl font-display text-shadow-golden">Background Jobs</h2>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            void loadInitial()
+            void refetchSummary()
+          }}
+        >
           Refresh
         </Button>
       </div>
 
-      {/* Status Filters */}
-      <div class="mb-6 flex flex-wrap gap-2">
-        <Button
-          variant={statusFilter() === undefined ? 'primary' : 'outline'}
-          onClick={() => {
-            handleStatusFilter(undefined)
-          }}
-        >
-          All
-        </Button>
-        <Button
-          variant={statusFilter() === 'queued' ? 'primary' : 'outline'}
-          onClick={() => {
-            handleStatusFilter('queued')
-          }}
-        >
-          Queued
-        </Button>
-        <Button
-          variant={statusFilter() === 'running' ? 'primary' : 'outline'}
-          onClick={() => {
-            handleStatusFilter('running')
-          }}
-        >
-          Running
-        </Button>
-        <Button
-          variant={statusFilter() === 'done' ? 'primary' : 'outline'}
-          onClick={() => {
-            handleStatusFilter('done')
-          }}
-        >
-          Done
-        </Button>
-        <Button
-          variant={statusFilter() === 'failed' ? 'primary' : 'outline'}
-          onClick={() => {
-            handleStatusFilter('failed')
-          }}
-        >
-          Failed
-        </Button>
-        <Button
-          variant={statusFilter() === 'cancelled' ? 'primary' : 'outline'}
-          onClick={() => {
-            handleStatusFilter('cancelled')
-          }}
-        >
-          Cancelled
-        </Button>
-      </div>
+      <JobStatStrip
+        summary={summary()}
+        activeStatus={statusFilter()}
+        onToggleStatus={toggleStatus}
+      />
 
-      {/* Jobs Table */}
-      <Show
-        when={!jobsResource.loading}
-        fallback={<p class="text-muted text-center py-8">Loading jobs...</p>}
-      >
+      <JobFilters
+        kind={kindFilter()}
+        onKindChange={setKindFilter}
+        kindStats={summary()?.kinds_recent}
+      />
+
+      <Show when={actionError()}>
+        <div class="mb-4">
+          <Alert variant="danger">
+            <div class="flex items-center justify-between gap-2">
+              <span>{actionError()}</span>
+              <Button variant="ghost" size="sm" onClick={() => setActionError(null)}>
+                ✕
+              </Button>
+            </div>
+          </Alert>
+        </div>
+      </Show>
+
+      <Show when={!loading()} fallback={<p class="text-muted text-center py-8">Loading jobs…</p>}>
         <Show
-          when={!jobsResource.error}
+          when={!loadError()}
           fallback={
             <div class="text-danger text-center py-8">
-              <p>
-                Error loading jobs:{' '}
-                {jobsResource.error instanceof Error ? jobsResource.error.message : 'Unknown error'}
-              </p>
-              <Button variant="ghost" onClick={() => void refetch()} class="mt-4">
+              <p>Error loading jobs: {loadError()}</p>
+              <Button variant="ghost" onClick={() => void loadInitial()} class="mt-4">
                 Retry
               </Button>
             </div>
           }
         >
           <Show
-            when={jobsResource()?.length}
-            fallback={<div class="text-center py-8">No jobs found</div>}
+            when={jobs().length > 0}
+            fallback={<div class="text-center py-8 text-muted">No jobs found</div>}
           >
-            <div class="arcane-card overflow-x-auto">
-              <table class="min-w-full divide-y divide-border">
-                <thead class="bg-muted/50">
-                  <tr>
-                    <th
-                      scope="col"
-                      class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider"
-                    >
-                      ID
-                    </th>
-                    <th
-                      scope="col"
-                      class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider"
-                    >
-                      Kind
-                    </th>
-                    <th
-                      scope="col"
-                      class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider"
-                    >
-                      Model
-                    </th>
-                    <th
-                      scope="col"
-                      class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider"
-                    >
-                      Status
-                    </th>
-                    <th
-                      scope="col"
-                      class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider"
-                    >
-                      Attempts
-                    </th>
-                    <th
-                      scope="col"
-                      class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider"
-                    >
-                      Priority
-                    </th>
-                    <th
-                      scope="col"
-                      class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider"
-                    >
-                      Created
-                    </th>
-                    <th
-                      scope="col"
-                      class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider"
-                    >
-                      Run time
-                    </th>
-                    <th
-                      scope="col"
-                      class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider"
-                    >
-                      Params
-                    </th>
-                    <th
-                      scope="col"
-                      class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider"
-                    >
-                      Error
-                    </th>
-                    <th
-                      scope="col"
-                      class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider"
-                    >
-                      Actions
-                    </th>
-                  </tr>
-                </thead>
-                <tbody class="bg-background divide-y divide-border">
-                  <For each={jobsResource()}>
-                    {(job: JobRow) => (
-                      <tr class="hover:bg-muted/30 transition-colors">
-                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">{job.id}</td>
-                        <td class="px-6 py-4 whitespace-nowrap text-sm">{job.kind}</td>
-                        <td class="px-6 py-4 whitespace-nowrap text-sm">
-                          <Show when={job.model} fallback={<span class="text-muted">-</span>}>
-                            <span class="font-mono text-xs text-muted">{job.model}</span>
-                          </Show>
-                        </td>
-                        <td class="px-6 py-4 whitespace-nowrap">
-                          <span
-                            class={`px-2 py-1 inline-flex text-xs leading-5 font-semibold rounded-full ${STATUS_STYLES[job.status]}`}
-                          >
-                            {job.status}
-                          </span>
-                        </td>
-                        <td class="px-6 py-4 whitespace-nowrap text-sm">
-                          {job.attempts} / {job.max_attempts}
-                        </td>
-                        <td class="px-6 py-4 whitespace-nowrap text-sm">{job.priority ?? 0}</td>
-                        <td class="px-6 py-4 whitespace-nowrap text-sm text-muted">
-                          {job.created_at ? formatLocalDateTimeISO(job.created_at) : '-'}
-                        </td>
-                        <td
-                          class="px-6 py-4 whitespace-nowrap text-sm text-muted"
-                          title={
-                            job.duration_ms != null ? `${String(job.duration_ms)} ms` : undefined
-                          }
-                        >
-                          {formatRunDurationSeconds(
-                            job.duration_ms ?? durationMsFromResult(job.result)
-                          )}
-                        </td>
-                        <td class="px-6 py-4 whitespace-nowrap text-sm text-muted">
-                          <Show when={job.link_path} fallback={<span>{extractParams(job)}</span>}>
-                            <A href={job.link_path as string} class="text-accent hover:underline">
-                              {extractParams(job)}
-                            </A>
-                          </Show>
-                        </td>
-                        <td class="px-6 py-4 text-sm text-muted">
-                          <Show when={job.last_error} fallback={<span class="text-muted">-</span>}>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => setErrorModalJob(job)}
-                              class="text-red-600 hover:text-red-700"
-                            >
-                              View Error
-                            </Button>
-                          </Show>
-                        </td>
-                        <td class="px-6 py-4 whitespace-nowrap text-sm">
-                          <Show when={job.status === 'queued' || job.status === 'running'}>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => void handleCancelJob(job.id)}
-                              disabled={cancellingJobId() === job.id}
-                            >
-                              {cancellingJobId() === job.id ? 'Cancelling...' : 'Cancel'}
-                            </Button>
-                          </Show>
-                        </td>
-                      </tr>
-                    )}
-                  </For>
-                </tbody>
-              </table>
+            <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+              <For each={jobs()}>
+                {(job) => (
+                  <JobCard
+                    job={job}
+                    now={now()}
+                    onShowError={setErrorModalJob}
+                    onCancel={setCancelTarget}
+                  />
+                )}
+              </For>
             </div>
-            <div class="mt-4 text-sm text-muted">
-              Showing {jobsResource()?.length ?? 0} jobs (limit: 100)
-            </div>
+            <Show when={hasMore()}>
+              <Button
+                variant="outline"
+                class="w-full mt-4"
+                onClick={() => void loadMore()}
+                disabled={loadingMore()}
+              >
+                {loadingMore() ? 'Loading…' : 'Load more'}
+              </Button>
+            </Show>
+            <div class="mt-3 text-xs text-muted text-center">Showing {jobs().length} jobs</div>
           </Show>
         </Show>
       </Show>
 
-      {/* Error Modal */}
-      <Show when={errorModalJob()}>
-        <div
-          class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-          onClick={() => setErrorModalJob(null)}
-        >
-          <div
-            class="arcane-card max-w-3xl max-h-[80vh] w-full mx-4 overflow-hidden flex flex-col"
-            onClick={(e) => {
-              e.stopPropagation()
-            }}
-          >
-            <div class="flex items-center justify-between p-6 border-b border-border">
-              <h2 class="text-xl font-display">
-                Job Error - {errorModalJob()?.kind} #{errorModalJob()?.id}
-              </h2>
-              <Button variant="ghost" size="sm" onClick={() => setErrorModalJob(null)}>
-                ✕
-              </Button>
-            </div>
-            <div class="p-6 overflow-auto">
-              <pre class="text-xs font-mono bg-muted/50 p-4 rounded overflow-x-auto whitespace-pre-wrap break-words">
-                {errorModalJob()?.last_error || 'No error message available'}
-              </pre>
-            </div>
-            <div class="flex justify-end gap-2 p-6 border-t border-border">
-              <Button variant="secondary" onClick={() => setErrorModalJob(null)}>
-                Close
-              </Button>
-            </div>
-          </div>
-        </div>
-      </Show>
+      <JobErrorModal job={errorModalJob()} onClose={() => setErrorModalJob(null)} />
+
+      <ConfirmationModal
+        isOpen={cancelTarget() !== null}
+        title="Cancel job"
+        message={
+          <>
+            Cancel {cancelTarget()?.kind} #{cancelTarget()?.id}?
+          </>
+        }
+        confirmText="Cancel job"
+        cancelText="Keep running"
+        onConfirm={() => void confirmCancel()}
+        onCancel={() => setCancelTarget(null)}
+        isConfirming={cancelling()}
+      />
     </main>
   )
 }

--- a/web/src/utils/job-management.ts
+++ b/web/src/utils/job-management.ts
@@ -455,7 +455,9 @@ export function adoptJobHandoff(options: JobHandoffAdoptionOptions) {
         listJobs({ course_id: currentEntity.id, status: 'queued', limit: 100 }),
         listJobs({ course_id: currentEntity.id, status: 'running', limit: 100 }),
       ])
-      const activeJobs = [...queued, ...running].filter((job) => matchesJobKind(job, options.kinds))
+      const activeJobs = [...queued.jobs, ...running.jobs].filter((job) =>
+        matchesJobKind(job, options.kinds)
+      )
       for (const job of activeJobs) trackOnce(job.id)
       await discoverChildren(activeJobs.map((job) => job.id))
     } catch (error) {
@@ -604,6 +606,33 @@ export function getJobMessage(
 
   const kindMessages = messages[kind]
   return kindMessages ? kindMessages[status] || `${kind} ${status}` : `${kind} ${status}`
+}
+
+/** Short human-readable names for job kinds (getJobMessage yields sentences, not names). */
+const JOB_KIND_LABELS: Record<string, string> = {
+  generate_course: 'Course',
+  generate_department: 'Department',
+  generate_professor: 'Professor',
+  generate_professor_image: 'Professor image',
+  generate_course_image: 'Course image',
+  generate_topics_for_course: 'Course topics',
+  generate_tags_for_course: 'Course tags',
+  generate_lecture: 'Lecture',
+  generate_lecture_text_only: 'Lecture text',
+  generate_lecture_summary: 'Lecture summary',
+  generate_lecture_audio: 'Lecture audio',
+  generate_lecture_timeline: 'Audio timeline',
+  generate_lecture_images: 'Image planning',
+  resume_lecture_images: 'Image resume',
+  generate_lecture_slide: 'Lecture image',
+  remap_lecture_images_timeline: 'Image timeline remap',
+}
+
+/** Known job kinds, for filter UIs. */
+export const JOB_KINDS: string[] = Object.keys(JOB_KIND_LABELS)
+
+export function getJobKindLabel(kind: string): string {
+  return JOB_KIND_LABELS[kind] ?? kind
 }
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))


### PR DESCRIPTION
Redesigns the admin Background Jobs view from a wide 11-column table into a mobile-first dashboard, and fixes the underlying API problems that made the old page slow and jumpy.

## Problems addressed

- Initial load slowed as the jobs table grew: the list endpoint returned 100 full rows with **N+1 queries** (a preference lookup and lecture/topic course lookup per row).
- The page "refreshed" disruptively: any SSE event for a job not in the list triggered a full refetch, replacing the whole table mid-interaction.
- Wide table forced horizontal scrolling on mobile.
- No filter by job kind (the API supported it; the UI never exposed it).
- **Bug**: every `generate_lecture_audio` job displayed the globally configured TTS backend (`elevenlabs`) as its model, even when the professor/voice actually used Mistral or xAI — the resolved backend was computed at generation time and then discarded.

## Backend

- `generate_lecture_audio` now records the resolved backend in the job result (`tts_backend`); `_job_model_name` prefers this recorded value over payload overrides and the settings default. `TTSService`'s default path also honors `settings.tts_backend` instead of a hardcoded `"elevenlabs"`.
- `GET /jobs` uses keyset pagination: `before_id` param, `ORDER BY id DESC`, default limit 25 (clamped 1–100), and returns a `{jobs, has_more, next_before_id}` envelope. A per-request cache memoizes preference and lecture/topic→course lookups across rows.
- `GET /jobs/summary` now returns full dashboard stats via a new `JobRepository.dashboard_stats()`: counts by status, avg queued wait, failures in the last hour, and per-kind count/avg/p50 duration over a recent window (aggregated from `result._job_telemetry.duration_ms` JSONB — no schema migration).

## Frontend

- `Jobs.tsx` rebuilt as a dashboard: status-count tiles that double as filters, a kind filter with recent per-kind timing stats, and a responsive card feed (1 column mobile → 3 columns desktop).
- New pure module `web/src/components/jobs/job-feed.ts` folds SSE events into the feed: known jobs are patched in place (cards persist across status transitions even when they stop matching the active filter), unknown jobs are prepended as provisional cards hydrated by a single `getJob` fetch. **The feed is never wholesale refetched from the event stream.**
- Running jobs show a live-ticking elapsed time (1s clock active only while something is running); completed jobs show their recorded duration.
- "Load more" appends older pages via the keyset cursor; cancel uses the shared `ConfirmationModal` instead of native `confirm()`; errors open in a modal from a tappable truncated preview.
- `Badge` gains `warning`/`info` variants; job-kind labels centralized in `job-management.ts` (`JOB_KINDS`, `getJobKindLabel`).

## Tests

- `tests/api/test_jobs.py` (new): envelope/has_more, filter and cursor forwarding, model precedence (recorded backend → payload override → settings), memoized lookups, summary passthrough and window clamping.
- `tests/integration/test_repository.py`: keyset pagination and `dashboard_stats` aggregation against a real database.
- `web/src/components/jobs/job-feed.test.ts` (new): 12 cases covering event folding, snapshot merging, page appends, and formatting helpers.

Frontend verified locally: ESLint, Stylelint, Biome, vitest (19 passing), production build. Backend files pass black/isort/flake8; pytest could not run in the dev sandbox (no Python 3.14 available), so CI is the authoritative run for the Python tests.

## Notes

- Accepted limitation of the no-migration approach: a queued/running audio job shows the configured default backend until it completes, since the true backend is only recorded in the result. A real `model` column could fix this later.
- `GET /jobs` response shape changed (array → envelope); both consumers (`Jobs.tsx`, `job-management.ts`) are updated in this PR. `GET /jobs/summary` had no consumers before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6pdyAhZyGNZGfNiiNNFXL

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6pdyAhZyGNZGfNiiNNFXL)_