### PR TITLE
Add Qwen (Alibaba) qwen-audio-3.0-tts as a fourth TTS backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,12 +2,13 @@
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/artificial_u_dev
 
 # API Keys
+ALIBABA_API_KEY=
 ANTHROPIC_API_KEY=
 ELEVENLABS_API_KEY=
-MISTRAL_API_KEY=
-XAI_API_KEY=
 GOOGLE_API_KEY=
+MISTRAL_API_KEY=
 OPENAI_API_KEY=
+XAI_API_KEY=
 
 # Configuration
 LECTURE_IMAGE_INTERVAL_SEC=45
@@ -37,6 +38,18 @@ PROFESSOR_GENERATION_MODEL=gpt-5.4-nano
 TOPICS_GENERATION_MODEL=gemini-3.6-flash
 IMAGE_GENERATION_MODEL=gemini-3.1-flash-lite-image
 TTS_VOICE_MODEL=eleven_flash_v2_5
+
+# TTS backend selection: elevenlabs | mistral | xai | qwen
+# tts_backend=elevenlabs
+# Qwen (Alibaba Model Studio) TTS — used only when tts_backend=qwen
+# NOTE: qwen-audio-3.0-tts is hosted only in the Singapore and Beijing regions.
+# It is NOT available in us-east-1 (Virginia). Your ALIBABA_API_KEY must be a
+# Singapore- or Beijing-region key (keys are region-locked).
+# TTS_QWEN_MODEL=qwen-audio-3.0-tts-flash
+# WebSocket endpoint; must match the region your ALIBABA_API_KEY was created in:
+#   Singapore: wss://dashscope-intl.aliyuncs.com/api-ws/v1/inference  (default)
+#   Beijing:   wss://dashscope.aliyuncs.com/api-ws/v1/inference
+# ALIBABA_TTS_WSS_URL=wss://dashscope-intl.aliyuncs.com/api-ws/v1/inference
 
 # Text Generation Models
 # claude-opus-4-8

--- a/.env.test
+++ b/.env.test
@@ -2,12 +2,13 @@
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/artificial_u_test
 
 # Test API Keys (these will be mocked in automated tests)
+ALIBABA_API_KEY=test_alibaba_key
 ANTHROPIC_API_KEY=test_anthropic_key
 ELEVENLABS_API_KEY=test_elevenlabs_key
-MISTRAL_API_KEY=test_mistral_key
-XAI_API_KEY=test_xai_key
 GOOGLE_API_KEY=test_google_key
+MISTRAL_API_KEY=test_mistral_key
 OPENAI_API_KEY=test_openai_key
+XAI_API_KEY=test_xai_key
 
 # Test Configuration
 LOG_LEVEL=WARN

--- a/.github/workflows/test-quick.yml
+++ b/.github/workflows/test-quick.yml
@@ -50,6 +50,7 @@ jobs:
           ELEVENLABS_API_KEY=test_elevenlabs_key
           MISTRAL_API_KEY=test_mistral_key
           XAI_API_KEY=test_xai_key
+          ALIBABA_API_KEY=test_alibaba_key
           GOOGLE_API_KEY=test_google_key
           OPENAI_API_KEY=test_openai_key
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,6 +129,7 @@ jobs:
           ELEVENLABS_API_KEY=test_elevenlabs_key
           MISTRAL_API_KEY=test_mistral_key
           XAI_API_KEY=test_xai_key
+          ALIBABA_API_KEY=test_alibaba_key
           GOOGLE_API_KEY=test_google_key
           OPENAI_API_KEY=test_openai_key
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -346,6 +346,7 @@ Required in `.env` file:
 
 - `ANTHROPIC_API_KEY`: Anthropic Claude API key
 - `ELEVENLABS_API_KEY`: ElevenLabs TTS API key
+- `ALIBABA_API_KEY`: Alibaba Cloud API key (TTS when using Qwen backend)
 - `MISTRAL_API_KEY`: Mistral API key (TTS when using Mistral backend)
 - `XAI_API_KEY`: xAI API key (TTS when using xAI/Grok backend)
 - `DATABASE_URL`: PostgreSQL connection string

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,6 +346,7 @@ Required in `.env` file:
 
 - `ANTHROPIC_API_KEY`: Anthropic Claude API key
 - `ELEVENLABS_API_KEY`: ElevenLabs TTS API key
+- `ALIBABA_API_KEY`: Alibaba Cloud API key (TTS when using Qwen backend)
 - `MISTRAL_API_KEY`: Mistral API key (TTS when using Mistral backend)
 - `XAI_API_KEY`: xAI API key (TTS when using xAI/Grok backend)
 - `DATABASE_URL`: PostgreSQL connection string

--- a/artificial_u/api/routers/voices.py
+++ b/artificial_u/api/routers/voices.py
@@ -411,6 +411,71 @@ async def list_xai_catalog(
 
 
 # ---------------------------------------------------------------------------
+# Qwen (Alibaba) voice catalog (static preset list)
+# ---------------------------------------------------------------------------
+
+
+class QwenVoiceCatalogItem(BaseModel):
+    """A Qwen preset voice, mapped into a shape the frontend can use."""
+
+    id: str = Field(..., description="Qwen voice id (e.g. 'loongeva_v3.6')")
+    name: str = Field(..., description="Display name")
+    gender: Optional[str] = None
+    description: Optional[str] = None
+    languages: Optional[list] = None
+    model: Optional[str] = Field(None, description="qwen-audio TTS model this voice belongs to")
+
+
+class QwenVoiceCatalogResponse(BaseModel):
+    items: list[QwenVoiceCatalogItem]
+    total: int
+
+
+@router.get(
+    "/qwen/catalog",
+    response_model=QwenVoiceCatalogResponse,
+    dependencies=[Depends(require_auth)],
+)
+async def list_qwen_catalog(
+    language: Optional[str] = Query(None, description="Filter by language prefix (e.g. 'en')"),
+    gender: Optional[str] = Query(None, description="Filter by gender"),
+):
+    """
+    List the Qwen (Alibaba) preset voices.
+
+    Alibaba exposes no voice-list API for qwen-audio-3.0-tts, so this serves a
+    static catalog. These are **not** stored in our database; the frontend uses
+    the Qwen voice ``id`` as the ``voice_id`` when previewing or assigning.
+    """
+    from artificial_u.integrations.qwen.voice_manager import QwenVoiceManager
+
+    raw_voices = QwenVoiceManager().list_voices()
+
+    items: list[QwenVoiceCatalogItem] = []
+    for v in raw_voices:
+        # Optional client-side filters
+        if language:
+            langs = v.get("languages") or []
+            if not any(str(lang).startswith(language) for lang in langs):
+                continue
+        if gender and v.get("gender") != gender:
+            continue
+
+        items.append(
+            QwenVoiceCatalogItem(
+                id=v["id"],
+                name=v.get("name") or v["id"],
+                gender=v.get("gender"),
+                description=v.get("description"),
+                languages=v.get("languages"),
+                model=v.get("model"),
+            )
+        )
+
+    return QwenVoiceCatalogResponse(items=items, total=len(items))
+
+
+# ---------------------------------------------------------------------------
 # Voice preview (TTS sample generation)
 # ---------------------------------------------------------------------------
 

--- a/artificial_u/audio/speech_processor.py
+++ b/artificial_u/audio/speech_processor.py
@@ -36,8 +36,8 @@ class SpeechProcessor:
         Args:
             text: The text to normalize.
             backend_name: TTS backend the text is destined for
-                ("elevenlabs", "mistral", "xai"). Unknown backends fall back to
-                clean prose (pause directions stripped, no markup).
+                ("elevenlabs", "mistral", "xai", "qwen"). Unknown backends fall
+                back to clean prose (pause directions stripped, no markup).
 
         Returns:
             Normalized text suitable for the given TTS backend.
@@ -52,6 +52,10 @@ class SpeechProcessor:
             normalized_text = self._process_xai(normalized_text)
         elif backend_name == "mistral":
             # No markup support: strip bracketed pause directions entirely.
+            normalized_text = self._strip_pause_directions(normalized_text)
+        elif backend_name == "qwen":
+            # Qwen supports its own inline tags ([excited], [laughing], ...) but
+            # our lecture stage directions aren't in that set: strip them.
             normalized_text = self._strip_pause_directions(normalized_text)
         else:
             self.logger.debug(

--- a/artificial_u/config/__init__.py
+++ b/artificial_u/config/__init__.py
@@ -4,12 +4,14 @@ Configuration modules for the ArtificialU system.
 
 # Re-export defaults for direct import from artificial_u.config
 from artificial_u.config.defaults import (
+    DEFAULT_ALIBABA_TTS_WSS_URL,
     DEFAULT_CONTENT_BACKEND,
     DEFAULT_CONTENT_LOGS_PATH,
     DEFAULT_DB_URL,
     DEFAULT_LECTURE_IMAGE_INTERVAL_SEC,
     DEFAULT_LECTURE_WORD_COUNT,
     DEFAULT_LOG_LEVEL,
+    DEFAULT_QWEN_TTS_MODEL,
     DEFAULT_STORAGE_AUDIO_BUCKET,
     DEFAULT_STORAGE_CONTENT_LOGS_BUCKET,
     DEFAULT_STORAGE_ENDPOINT_URL,
@@ -52,6 +54,8 @@ __all__ = [
     "DEFAULT_CONTENT_BACKEND",
     # TTS defaults
     "DEFAULT_TTS_BACKEND",
+    "DEFAULT_QWEN_TTS_MODEL",
+    "DEFAULT_ALIBABA_TTS_WSS_URL",
     # Course and lecture defaults
     "DEFAULT_LECTURE_IMAGE_INTERVAL_SEC",
     "DEFAULT_LECTURE_WORD_COUNT",

--- a/artificial_u/config/defaults.py
+++ b/artificial_u/config/defaults.py
@@ -22,6 +22,12 @@ DEFAULT_CONTENT_LOGS_PATH = "content_logs"
 DEFAULT_TTS_BACKEND = "elevenlabs"
 DEFAULT_XAI_TTS_BASE_URL = "https://api.x.ai/v1"
 DEFAULT_XAI_TTS_LANGUAGE = "en"
+DEFAULT_QWEN_TTS_MODEL = "qwen-audio-3.0-tts-flash"
+# Alibaba Model Studio WebSocket endpoint. qwen-audio-3.0-tts is served only
+# from the Singapore and Beijing regions (NOT us-east-1/Virginia, which 404s
+# on the websocket route), so the ALIBABA_API_KEY must be a Singapore- or
+# Beijing-region key. Singapore -> dashscope-intl, Beijing -> dashscope.
+DEFAULT_ALIBABA_TTS_WSS_URL = "wss://dashscope-intl.aliyuncs.com/api-ws/v1/inference"
 
 # Storage defaults (MinIO/S3)
 DEFAULT_STORAGE_TYPE = "minio"  # "minio" or "s3"

--- a/artificial_u/config/settings.py
+++ b/artificial_u/config/settings.py
@@ -15,6 +15,7 @@ from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from artificial_u.config.defaults import (
+    DEFAULT_ALIBABA_TTS_WSS_URL,
     DEFAULT_CONTENT_BACKEND,
     DEFAULT_CONTENT_LOGS_PATH,
     DEFAULT_DB_MAX_OVERFLOW,
@@ -26,6 +27,7 @@ from artificial_u.config.defaults import (
     DEFAULT_LECTURE_IMAGE_INTERVAL_SEC,
     DEFAULT_LECTURE_WORD_COUNT,
     DEFAULT_LOG_LEVEL,
+    DEFAULT_QWEN_TTS_MODEL,
     DEFAULT_STORAGE_AUDIO_BUCKET,
     DEFAULT_STORAGE_CONTENT_LOGS_BUCKET,
     DEFAULT_STORAGE_ENDPOINT_URL,
@@ -94,6 +96,7 @@ class Settings(BaseSettings):
     LOG_LEVEL: str = DEFAULT_LOG_LEVEL
 
     # API Keys
+    ALIBABA_API_KEY: Optional[str] = None
     ANTHROPIC_API_KEY: Optional[str] = None
     ELEVENLABS_API_KEY: Optional[str] = None
     GOOGLE_API_KEY: Optional[str] = None
@@ -150,7 +153,7 @@ class Settings(BaseSettings):
     LECTURE_IMAGE_INTERVAL_SEC: int = DEFAULT_LECTURE_IMAGE_INTERVAL_SEC
 
     # Text-to-speech settings
-    tts_backend: str = DEFAULT_TTS_BACKEND  # "elevenlabs", "mistral", or "xai"
+    tts_backend: str = DEFAULT_TTS_BACKEND  # "elevenlabs", "mistral", "xai", or "qwen"
     # ElevenLabs voice model. Example values: "eleven_flash_v2_5", "eleven_multilingual_v2"
     TTS_VOICE_MODEL: str = "eleven_flash_v2_5"
     # Mistral TTS model
@@ -161,6 +164,10 @@ class Settings(BaseSettings):
     XAI_TTS_BASE_URL: str = DEFAULT_XAI_TTS_BASE_URL
     # Default output language (BCP-47 code) for backends that accept one (e.g. xAI)
     XAI_TTS_LANGUAGE: str = DEFAULT_XAI_TTS_LANGUAGE
+    # Qwen (Alibaba Model Studio) TTS settings (used only if tts_backend="qwen")
+    TTS_QWEN_MODEL: str = DEFAULT_QWEN_TTS_MODEL
+    # WebSocket endpoint; must match the region the ALIBABA_API_KEY was created in
+    ALIBABA_TTS_WSS_URL: str = DEFAULT_ALIBABA_TTS_WSS_URL
 
     # Coin costs for generation operations (can be tuned via environment variables)
     COIN_COST_COURSE_GENERATION: int = 1
@@ -276,6 +283,7 @@ class Settings(BaseSettings):
             "elevenlabs_api_key": self.ELEVENLABS_API_KEY,
             "mistral_api_key": self.MISTRAL_API_KEY,
             "xai_api_key": self.XAI_API_KEY,
+            "alibaba_api_key": self.ALIBABA_API_KEY,
             "google_api_key": self.GOOGLE_API_KEY,
             "openai_api_key": self.OPENAI_API_KEY,
             "storage_type": self.STORAGE_TYPE,

--- a/artificial_u/integrations/qwen/__init__.py
+++ b/artificial_u/integrations/qwen/__init__.py
@@ -1,0 +1,1 @@
+"""Qwen (Alibaba Cloud Model Studio) integration package."""

--- a/artificial_u/integrations/qwen/tts_client.py
+++ b/artificial_u/integrations/qwen/tts_client.py
@@ -1,0 +1,123 @@
+"""
+Qwen (Alibaba) TTS client.
+
+Wraps the dashscope SDK's synchronous SpeechSynthesizer, which drives the
+qwen-audio-3.0-tts WebSocket protocol and returns complete audio bytes.
+The endpoint is region-locked to the API key (see ALIBABA_TTS_WSS_URL).
+"""
+
+import logging
+import os
+import sys
+import time
+from typing import Optional
+
+from artificial_u.config import get_settings
+from artificial_u.integrations.qwen.voice_manager import model_for_voice
+
+
+class QwenTTSClient:
+    """Low-level client for Alibaba Model Studio Qwen text-to-speech."""
+
+    DEFAULT_VOICE = "loongeva_v3.6"
+
+    MAX_RETRIES = 3
+    RETRY_WAIT = 2
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        wss_url: Optional[str] = None,
+        logger: Optional[logging.Logger] = None,
+    ):
+        """Initialize the Qwen TTS client.
+
+        Args:
+            api_key: Alibaba Cloud API key. Falls back to ALIBABA_API_KEY env/settings.
+            wss_url: Override the Model Studio WebSocket endpoint.
+            logger: Optional logger.
+        """
+        self.logger = logger or logging.getLogger(__name__)
+        settings = get_settings()
+
+        in_test_env = os.environ.get("TESTING") == "true" or "pytest" in sys.modules
+
+        self.api_key = api_key or os.environ.get("ALIBABA_API_KEY") or settings.ALIBABA_API_KEY
+        if not self.api_key:
+            if in_test_env:
+                self.api_key = "test_alibaba_key"
+                self.logger.info("Using test API key in test environment")
+            else:
+                raise ValueError("Alibaba API key is required for Qwen TTS")
+
+        self.wss_url = wss_url or settings.ALIBABA_TTS_WSS_URL
+        self.default_model = settings.TTS_QWEN_MODEL
+
+    def text_to_speech(
+        self,
+        text: str,
+        voice_id: str = DEFAULT_VOICE,
+        model: Optional[str] = None,
+    ) -> bytes:
+        """Convert text to speech via the Qwen TTS WebSocket API.
+
+        Args:
+            text: Text to convert.
+            voice_id: Qwen preset voice id (e.g. loongeva_v3.6, loongjohn).
+            model: Model override. Defaults to the model the voice belongs to
+                (plus-tier voices need qwen-audio-3.0-tts-plus), falling back
+                to settings.TTS_QWEN_MODEL.
+
+        Returns:
+            Audio data as mp3 bytes.
+        """
+        # Imported lazily so the module (and test mocks) load without the SDK
+        # opening network resources at import time.
+        import dashscope
+        from dashscope.audio.tts_v2 import AudioFormat, SpeechSynthesizer
+
+        effective_voice_id = voice_id or self.DEFAULT_VOICE
+        effective_model = model or model_for_voice(effective_voice_id) or self.default_model
+
+        # The SDK reads the key from module state; there is no per-call param.
+        dashscope.api_key = self.api_key
+
+        for attempt in range(self.MAX_RETRIES):
+            try:
+                self.logger.debug(
+                    "Qwen TTS attempt %d: model=%s, voice=%s, text_len=%d",
+                    attempt + 1,
+                    effective_model,
+                    effective_voice_id,
+                    len(text),
+                )
+                # SpeechSynthesizer instances are single-use: one per call.
+                synthesizer = SpeechSynthesizer(
+                    model=effective_model,
+                    voice=effective_voice_id,
+                    format=AudioFormat.MP3_24000HZ_MONO_256KBPS,
+                    url=self.wss_url,
+                )
+                audio_data = synthesizer.call(text)
+
+                if not audio_data:
+                    raise RuntimeError("Qwen TTS returned no audio data")
+                if len(audio_data) < 1000 and len(text) > 100:
+                    self.logger.warning(
+                        "Unexpectedly small audio from Qwen: %d bytes for %d chars",
+                        len(audio_data),
+                        len(text),
+                    )
+                return audio_data
+
+            except Exception as e:
+                self.logger.error("Qwen TTS error (attempt %d): %s", attempt + 1, e)
+                if attempt < self.MAX_RETRIES - 1:
+                    wait = self.RETRY_WAIT * (attempt + 1)
+                    self.logger.info("Waiting %ds before retry...", wait)
+                    time.sleep(wait)
+                    continue
+                raise
+
+        # Should not reach here, but satisfy type checker
+        raise RuntimeError("Qwen TTS failed after all retries")

--- a/artificial_u/integrations/qwen/voice_manager.py
+++ b/artificial_u/integrations/qwen/voice_manager.py
@@ -4,8 +4,18 @@ Qwen (Alibaba) voice manager.
 Alibaba Model Studio exposes no voice-list API for the qwen-audio-3.0-tts
 models, so the preset catalog is maintained here as a static list, taken from
 https://www.alibabacloud.com/help/en/model-studio/qwen-audio-tts-voice-list
-Every preset voice supports English; most are bilingual Mandarin+English.
-Each voice works only with the model it is listed under.
+
+The catalog has two kinds of entries:
+  * System voices — first-class voices whose ``voice`` parameter is a plain id
+    (e.g. ``longanlingxin``) tied to one model (plus or flash).
+  * Base voices — pre-generated cloned voices whose ``voice`` parameter is the
+    full model-prefixed name (e.g. ``qwen-audio-3.0-tts-plus-longyinghaikai``).
+    Alibaba publishes 1000+ of these; only a representative subset is listed
+    here. The same suffix works in both plus and flash; we standardize on plus.
+
+Child voices (age < 18) are intentionally omitted (Longjie Lidou, Long Paopao,
+Long Huohuo, and the young base voices). Base voices are Chinese (Mandarin)
+only, which is useful for Chinese-language content.
 """
 
 import logging
@@ -15,7 +25,7 @@ FLASH_MODEL = "qwen-audio-3.0-tts-flash"
 PLUS_MODEL = "qwen-audio-3.0-tts-plus"
 
 QWEN_VOICES: List[Dict[str, Any]] = [
-    # qwen-audio-3.0-tts-plus (flagship tier)
+    # ---- System voices: qwen-audio-3.0-tts-plus (flagship) ----
     {
         "id": "longanlingxin",
         "name": "Longan Lingxin",
@@ -27,12 +37,13 @@ QWEN_VOICES: List[Dict[str, Any]] = [
     {
         "id": "longanlufeng",
         "name": "Longan Lufeng",
-        "gender": "female",
+        "gender": "male",
         "description": "Bright and cheerful",
         "languages": ["zh", "en"],
         "model": PLUS_MODEL,
     },
-    # qwen-audio-3.0-tts-flash — native-English voices
+    # ---- System voices: qwen-audio-3.0-tts-flash ----
+    # Native-English voices
     {
         "id": "loongmary",
         "name": "Mary",
@@ -57,7 +68,7 @@ QWEN_VOICES: List[Dict[str, Any]] = [
         "languages": ["en"],
         "model": FLASH_MODEL,
     },
-    # qwen-audio-3.0-tts-flash — bilingual Mandarin+English voices
+    # Bilingual Mandarin+English voices
     {
         "id": "longanfengyue",
         "name": "Longan Fengyue",
@@ -99,36 +110,101 @@ QWEN_VOICES: List[Dict[str, Any]] = [
         "model": FLASH_MODEL,
     },
     {
-        "id": "longjielidou_v3.6",
-        "name": "Longjie Lidou",
-        "gender": "male",
-        "description": "Innocent boy",
-        "languages": ["zh", "en"],
-        "model": FLASH_MODEL,
-    },
-    {
-        "id": "longpaopao_v3.6",
-        "name": "Long Paopao",
-        "gender": "female",
-        "description": "Soft and adorable",
-        "languages": ["zh", "en"],
-        "model": FLASH_MODEL,
-    },
-    {
-        "id": "longhuohuo_v3.6",
-        "name": "Long Huohuo",
-        "gender": "male",
-        "description": "Mischievous boy",
-        "languages": ["zh", "en"],
-        "model": FLASH_MODEL,
-    },
-    {
         "id": "longchuanshu_v3.6",
         "name": "Long Chuanshu",
         "gender": "male",
         "description": "Sichuan-dialect storyteller",
         "languages": ["zh", "en"],
         "model": FLASH_MODEL,
+    },
+    # ---- Base (cloned) voices: Mandarin only, plus-tier ----
+    {
+        "id": "qwen-audio-3.0-tts-plus-longyinghaikai",
+        "name": "Long Ying Hai Kai",
+        "gender": "female",
+        "description": "Positive and upbeat",
+        "languages": ["zh"],
+        "model": PLUS_MODEL,
+    },
+    {
+        "id": "qwen-audio-3.0-tts-plus-longyinghaixuan",
+        "name": "Long Ying Hai Xuan",
+        "gender": "female",
+        "description": "Capable and composed",
+        "languages": ["zh"],
+        "model": PLUS_MODEL,
+    },
+    {
+        "id": "qwen-audio-3.0-tts-plus-longyingjingdong",
+        "name": "Long Ying Jing Dong",
+        "gender": "female",
+        "description": "Composed and professional",
+        "languages": ["zh"],
+        "model": PLUS_MODEL,
+    },
+    {
+        "id": "qwen-audio-3.0-tts-plus-longyinghaizhe",
+        "name": "Long Ying Hai Zhe",
+        "gender": "male",
+        "description": "Firm and persuasive",
+        "languages": ["zh"],
+        "model": PLUS_MODEL,
+    },
+    {
+        "id": "qwen-audio-3.0-tts-plus-longyingjinhao",
+        "name": "Long Ying Jin Hao",
+        "gender": "female",
+        "description": "Approachable and reliable",
+        "languages": ["zh"],
+        "model": PLUS_MODEL,
+    },
+    {
+        "id": "qwen-audio-3.0-tts-plus-longluanxuanling",
+        "name": "Long Luan Xuan Ling",
+        "gender": "female",
+        "description": "Gentle older-sister voice",
+        "languages": ["zh"],
+        "model": PLUS_MODEL,
+    },
+    {
+        "id": "qwen-audio-3.0-tts-plus-longhexiaoxuan",
+        "name": "Long He Xiao Xuan",
+        "gender": "male",
+        "description": "Refined and scholarly",
+        "languages": ["zh"],
+        "model": PLUS_MODEL,
+    },
+    {
+        "id": "qwen-audio-3.0-tts-plus-longsonglinwang",
+        "name": "Long Song Lin Wang",
+        "gender": "male",
+        "description": "Warm and magnetic",
+        "languages": ["zh"],
+        "model": PLUS_MODEL,
+    },
+    {
+        "id": "qwen-audio-3.0-tts-plus-longhuiluling",
+        "name": "Long Hui Lu Ling",
+        "gender": "female",
+        "description": "Gentle and caring",
+        "languages": ["zh"],
+        "model": PLUS_MODEL,
+    },
+    {
+        "id": "qwen-audio-3.0-tts-plus-longshuojizhu",
+        "name": "Long Shuo Ji Zhu",
+        "gender": "male",
+        "description": "Standard broadcasting voice",
+        "languages": ["zh"],
+        "model": PLUS_MODEL,
+    },
+    {
+        "id": "qwen-audio-3.0-tts-plus-longyufengmo",
+        "name": "Long Yu Feng Mo",
+        "gender": "female",
+        "description": "Gentle and resilient",
+        "languages": ["zh"],
+        "model": PLUS_MODEL,
     },
 ]
 

--- a/artificial_u/integrations/qwen/voice_manager.py
+++ b/artificial_u/integrations/qwen/voice_manager.py
@@ -1,0 +1,163 @@
+"""
+Qwen (Alibaba) voice manager.
+
+Alibaba Model Studio exposes no voice-list API for the qwen-audio-3.0-tts
+models, so the preset catalog is maintained here as a static list, taken from
+https://www.alibabacloud.com/help/en/model-studio/qwen-audio-tts-voice-list
+Every preset voice supports English; most are bilingual Mandarin+English.
+Each voice works only with the model it is listed under.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+FLASH_MODEL = "qwen-audio-3.0-tts-flash"
+PLUS_MODEL = "qwen-audio-3.0-tts-plus"
+
+QWEN_VOICES: List[Dict[str, Any]] = [
+    # qwen-audio-3.0-tts-plus (flagship tier)
+    {
+        "id": "longanlingxin",
+        "name": "Longan Lingxin",
+        "gender": "female",
+        "description": "Warm and empathetic",
+        "languages": ["zh", "en"],
+        "model": PLUS_MODEL,
+    },
+    {
+        "id": "longanlufeng",
+        "name": "Longan Lufeng",
+        "gender": "female",
+        "description": "Bright and cheerful",
+        "languages": ["zh", "en"],
+        "model": PLUS_MODEL,
+    },
+    # qwen-audio-3.0-tts-flash — native-English voices
+    {
+        "id": "loongmary",
+        "name": "Mary",
+        "gender": "female",
+        "description": "Warm British accent",
+        "languages": ["en"],
+        "model": FLASH_MODEL,
+    },
+    {
+        "id": "loongeva_v3.6",
+        "name": "Eva",
+        "gender": "female",
+        "description": "Intelligent and elegant",
+        "languages": ["en"],
+        "model": FLASH_MODEL,
+    },
+    {
+        "id": "loongjohn",
+        "name": "John",
+        "gender": "male",
+        "description": "Calm and friendly American accent",
+        "languages": ["en"],
+        "model": FLASH_MODEL,
+    },
+    # qwen-audio-3.0-tts-flash — bilingual Mandarin+English voices
+    {
+        "id": "longanfengyue",
+        "name": "Longan Fengyue",
+        "gender": "female",
+        "description": "Natural and friendly",
+        "languages": ["zh", "en"],
+        "model": FLASH_MODEL,
+    },
+    {
+        "id": "longanyuanfei",
+        "name": "Longan Yuanfei",
+        "gender": "female",
+        "description": "Proud and regal",
+        "languages": ["zh", "en"],
+        "model": FLASH_MODEL,
+    },
+    {
+        "id": "longanlingxi",
+        "name": "Longan Lingxi",
+        "gender": "female",
+        "description": "Cute and sweet",
+        "languages": ["zh", "en"],
+        "model": FLASH_MODEL,
+    },
+    {
+        "id": "longanxiaoxin",
+        "name": "Longan Xiaoxin",
+        "gender": "female",
+        "description": "Friendly and lively",
+        "languages": ["zh", "en"],
+        "model": FLASH_MODEL,
+    },
+    {
+        "id": "longanhuan_v3.6",
+        "name": "Longan Huan",
+        "gender": "female",
+        "description": "Gentle and soothing",
+        "languages": ["zh", "en"],
+        "model": FLASH_MODEL,
+    },
+    {
+        "id": "longjielidou_v3.6",
+        "name": "Longjie Lidou",
+        "gender": "male",
+        "description": "Innocent boy",
+        "languages": ["zh", "en"],
+        "model": FLASH_MODEL,
+    },
+    {
+        "id": "longpaopao_v3.6",
+        "name": "Long Paopao",
+        "gender": "female",
+        "description": "Soft and adorable",
+        "languages": ["zh", "en"],
+        "model": FLASH_MODEL,
+    },
+    {
+        "id": "longhuohuo_v3.6",
+        "name": "Long Huohuo",
+        "gender": "male",
+        "description": "Mischievous boy",
+        "languages": ["zh", "en"],
+        "model": FLASH_MODEL,
+    },
+    {
+        "id": "longchuanshu_v3.6",
+        "name": "Long Chuanshu",
+        "gender": "male",
+        "description": "Sichuan-dialect storyteller",
+        "languages": ["zh", "en"],
+        "model": FLASH_MODEL,
+    },
+]
+
+
+def model_for_voice(voice_id: str) -> Optional[str]:
+    """Return the qwen-audio model a preset voice belongs to, or None if unknown."""
+    for voice in QWEN_VOICES:
+        if voice["id"] == voice_id:
+            return voice["model"]
+    return None
+
+
+class QwenVoiceManager:
+    """Reads the static Qwen preset voice catalog."""
+
+    def __init__(self, logger: Optional[logging.Logger] = None):
+        self.logger = logger or logging.getLogger(__name__)
+
+    def list_voices(self) -> List[Dict[str, Any]]:
+        """List available Qwen preset voices.
+
+        Returns:
+            List of voice dicts: id, name, gender, description, languages, model.
+        """
+        return [dict(voice) for voice in QWEN_VOICES]
+
+    def get_voice(self, voice_id: str) -> Optional[Dict[str, Any]]:
+        """Return metadata for a single voice id, or None if not found."""
+        for voice in QWEN_VOICES:
+            if voice["id"] == voice_id:
+                return dict(voice)
+        return None

--- a/artificial_u/integrations/tts/factory.py
+++ b/artificial_u/integrations/tts/factory.py
@@ -17,7 +17,7 @@ def create_tts_backend(
     """Create a TTS backend instance.
 
     Args:
-        backend_name: Backend to use ("elevenlabs", "mistral", "xai").
+        backend_name: Backend to use ("elevenlabs", "mistral", "xai", "qwen").
             Defaults to settings.tts_backend.
         api_key: Optional API key override.
         logger: Optional logger.
@@ -52,8 +52,15 @@ def create_tts_backend(
             api_key=api_key or settings.XAI_API_KEY,
             logger=logger,
         )
+    elif backend_name == "qwen":
+        from artificial_u.integrations.tts.qwen_backend import QwenTTSBackend
+
+        return QwenTTSBackend(
+            api_key=api_key or settings.ALIBABA_API_KEY,
+            logger=logger,
+        )
     else:
         raise ValueError(
             f"Unknown TTS backend: '{backend_name}'. "
-            "Supported backends: 'elevenlabs', 'mistral', 'xai'"
+            "Supported backends: 'elevenlabs', 'mistral', 'xai', 'qwen'"
         )

--- a/artificial_u/integrations/tts/qwen_backend.py
+++ b/artificial_u/integrations/tts/qwen_backend.py
@@ -1,0 +1,65 @@
+"""
+Qwen (Alibaba) TTS backend adapter.
+
+Wraps QwenTTSClient to conform to the TTSBackend protocol.
+"""
+
+import logging
+from typing import Any, Dict, Optional
+
+from artificial_u.config import get_settings
+from artificial_u.integrations.qwen.tts_client import QwenTTSClient
+
+
+class QwenTTSBackend:
+    """TTS backend implementation for Alibaba Qwen."""
+
+    DEFAULT_VOICE = QwenTTSClient.DEFAULT_VOICE
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        client: Optional[QwenTTSClient] = None,
+        logger: Optional[logging.Logger] = None,
+    ):
+        self.logger = logger or logging.getLogger(__name__)
+        settings = get_settings()
+        api_key = api_key or getattr(settings, "ALIBABA_API_KEY", None)
+        self._client = client or QwenTTSClient(
+            api_key=api_key,
+            wss_url=getattr(settings, "ALIBABA_TTS_WSS_URL", None),
+            logger=self.logger,
+        )
+
+    @property
+    def backend_name(self) -> str:
+        return "qwen"
+
+    @property
+    def default_voice_settings(self) -> Dict[str, Any]:
+        return {}
+
+    def text_to_speech(
+        self,
+        text: str,
+        voice_id: str,
+        **kwargs: Any,
+    ) -> bytes:
+        """Convert text to speech using Alibaba Qwen.
+
+        Args:
+            text: Text to convert.
+            voice_id: Qwen preset voice id (e.g. loongeva_v3.6, loongjohn).
+            **kwargs: Optional overrides:
+                - model: qwen-audio TTS model id (defaults to the voice's model).
+
+        Returns:
+            Audio data as bytes.
+        """
+        effective_voice_id = voice_id or self.DEFAULT_VOICE
+
+        return self._client.text_to_speech(
+            text=text,
+            voice_id=effective_voice_id,
+            model=kwargs.get("model"),
+        )

--- a/artificial_u/services/voice_service.py
+++ b/artificial_u/services/voice_service.py
@@ -742,37 +742,8 @@ class VoiceService:
                 external_id=external_id,
                 name=external_id,
             )
-            # Try to enrich from the provider API (best-effort)
-            if tts_backend == "mistral":
-                try:
-                    from artificial_u.integrations.mistral.voice_manager import (
-                        MistralVoiceManager,
-                    )
-
-                    mgr = MistralVoiceManager()
-                    info = mgr.get_voice(external_id)
-                    if info:
-                        voice.name = info.get("name") or external_id
-                        voice.gender = info.get("gender")
-                        lang_list = info.get("languages") or []
-                        if lang_list:
-                            voice.language = str(lang_list[0])
-                except Exception as e:
-                    self.logger.warning("Could not enrich Mistral voice metadata: %s", e)
-            elif tts_backend == "xai":
-                try:
-                    from artificial_u.integrations.xai.voice_manager import (
-                        XAIVoiceManager,
-                    )
-
-                    info = XAIVoiceManager().get_voice(external_id)
-                    if info:
-                        voice.name = info.get("name") or external_id
-                        voice.gender = info.get("gender")
-                        voice.language = info.get("language")
-                        voice.category = "preset"
-                except Exception as e:
-                    self.logger.warning("Could not enrich xAI voice metadata: %s", e)
+            # Best-effort enrichment from the provider catalog
+            self._enrich_generic_voice(voice, tts_backend, external_id)
 
             voice = self.repository_factory.voice.upsert(voice)
             self.logger.info(
@@ -788,6 +759,48 @@ class VoiceService:
         self.logger.info(
             "Assigned voice %s (backend=%s) to professor %s", external_id, tts_backend, professor_id
         )
+
+    def _enrich_generic_voice(self, voice, tts_backend: str, external_id: str) -> None:
+        """Populate a new non-ElevenLabs Voice from its provider catalog, in place.
+
+        Best-effort: any provider lookup failure is logged and the voice keeps
+        its fallback (name == external_id).
+        """
+        try:
+            if tts_backend == "mistral":
+                from artificial_u.integrations.mistral.voice_manager import MistralVoiceManager
+
+                info = MistralVoiceManager().get_voice(external_id)
+                if info:
+                    voice.name = info.get("name") or external_id
+                    voice.gender = info.get("gender")
+                    lang_list = info.get("languages") or []
+                    if lang_list:
+                        voice.language = str(lang_list[0])
+            elif tts_backend == "xai":
+                from artificial_u.integrations.xai.voice_manager import XAIVoiceManager
+
+                info = XAIVoiceManager().get_voice(external_id)
+                if info:
+                    voice.name = info.get("name") or external_id
+                    voice.gender = info.get("gender")
+                    voice.language = info.get("language")
+                    voice.category = "preset"
+            elif tts_backend == "qwen":
+                from artificial_u.integrations.qwen.voice_manager import QwenVoiceManager
+
+                info = QwenVoiceManager().get_voice(external_id)
+                if info:
+                    voice.name = info.get("name") or external_id
+                    voice.gender = info.get("gender")
+                    voice.description = info.get("description")
+                    lang_list = info.get("languages") or []
+                    if lang_list:
+                        # All Qwen presets speak English; prefer it for filtering
+                        voice.language = "en" if "en" in lang_list else str(lang_list[0])
+                    voice.category = "preset"
+        except Exception as e:
+            self.logger.warning("Could not enrich %s voice metadata: %s", tts_backend, e)
 
     # ---------------------------------------------------------------------------
     # Voice Design

--- a/artificial_u/system.py
+++ b/artificial_u/system.py
@@ -37,6 +37,7 @@ class UniversitySystem:
         elevenlabs_api_key: Optional[str] = None,
         mistral_api_key: Optional[str] = None,
         xai_api_key: Optional[str] = None,
+        alibaba_api_key: Optional[str] = None,
         google_api_key: Optional[str] = None,
         openai_api_key: Optional[str] = None,
         db_url: Optional[str] = None,
@@ -55,6 +56,7 @@ class UniversitySystem:
             elevenlabs_api_key: API key for ElevenLabs
             mistral_api_key: API key for Mistral (TTS when using Mistral backend)
             xai_api_key: API key for xAI (TTS when using xAI backend)
+            alibaba_api_key: API key for Alibaba Cloud (TTS when using Qwen backend)
             google_api_key: API key for Google
             openai_api_key: API key for OpenAI
             db_url: PostgreSQL database URL
@@ -74,6 +76,7 @@ class UniversitySystem:
             elevenlabs_api_key,
             mistral_api_key,
             xai_api_key,
+            alibaba_api_key,
             google_api_key,
             openai_api_key,
         )
@@ -102,6 +105,7 @@ class UniversitySystem:
         elevenlabs_api_key: Optional[str],
         mistral_api_key: Optional[str],
         xai_api_key: Optional[str],
+        alibaba_api_key: Optional[str],
         google_api_key: Optional[str],
         openai_api_key: Optional[str],
     ):
@@ -114,6 +118,8 @@ class UniversitySystem:
             self.settings.MISTRAL_API_KEY = mistral_api_key
         if xai_api_key:
             self.settings.XAI_API_KEY = xai_api_key
+        if alibaba_api_key:
+            self.settings.ALIBABA_API_KEY = alibaba_api_key
         if google_api_key:
             self.settings.GOOGLE_API_KEY = google_api_key
         if openai_api_key:

--- a/conftest.py
+++ b/conftest.py
@@ -52,5 +52,7 @@ def verify_test_environment():
         assert settings.MISTRAL_API_KEY == "test_mistral_key", "Using incorrect Mistral key"
     if settings.XAI_API_KEY:
         assert settings.XAI_API_KEY == "test_xai_key", "Using incorrect xAI key"
+    if settings.ALIBABA_API_KEY:
+        assert settings.ALIBABA_API_KEY == "test_alibaba_key", "Using incorrect Alibaba key"
 
     yield

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -295,6 +295,7 @@ TESTING=true
 | `ELEVENLABS_API_KEY` | API key for ElevenLabs | None | No |
 | `MISTRAL_API_KEY` | API key for Mistral (TTS when using Mistral backend) | None | No |
 | `XAI_API_KEY` | API key for xAI (TTS when using xAI/Grok backend) | None | No |
+| `ALIBABA_API_KEY` | API key for Alibaba Cloud Model Studio (TTS when using Qwen backend). Must be a **Singapore- or Beijing-region** key — `qwen-audio-3.0-tts` is not hosted in us-east-1 | None | No |
 | `GOOGLE_API_KEY` | API key for Google | None | No |
 | `OPENAI_API_KEY` | API key for OpenAI | None | No |
 | `CONTENT_LOGS_PATH` | (Deprecated) Path for content generation logs | `content_logs` | No |
@@ -318,6 +319,8 @@ TESTING=true
 | `TTS_VOICE_MODEL` | Model for text-to-speech voice | `eleven_flash_v2_5` | No |
 | `XAI_TTS_BASE_URL` | Base URL for the xAI TTS API | `https://api.x.ai/v1` | No |
 | `XAI_TTS_LANGUAGE` | Default output language (BCP-47) for the xAI backend | `en` | No |
+| `TTS_QWEN_MODEL` | Qwen TTS model (`qwen-audio-3.0-tts-flash` or `qwen-audio-3.0-tts-plus`) | `qwen-audio-3.0-tts-flash` | No |
+| `ALIBABA_TTS_WSS_URL` | Model Studio WebSocket endpoint; **must match the region your `ALIBABA_API_KEY` was created in** (keys are region-locked). Singapore: `wss://dashscope-intl.aliyuncs.com/api-ws/v1/inference`; Beijing: `wss://dashscope.aliyuncs.com/api-ws/v1/inference` | `wss://dashscope-intl.aliyuncs.com/api-ws/v1/inference` | No |
 | `LECTURE_WORD_COUNT` | Target word count for generated lectures | `3000` | No |
 | `LECTURE_IMAGE_INTERVAL_SEC` | Approximate seconds between generated lecture images | `45` | No |
 | `STORAGE_TYPE` | Storage type ("minio" or "s3") | `minio` | No |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "anthropic>=0.86.0",
     "boto3>=1.42.73",
     "click>=8.2.0",
+    "dashscope>=1.26.4",
     "elevenlabs>=2.39.0",
     "fastapi>=0.135.1",
     "google-api-core>=2.28.1",

--- a/scripts/seed_qwen_voices.py
+++ b/scripts/seed_qwen_voices.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+Seed Qwen (Alibaba) preset voices into the voices table (idempotent).
+
+Upserts the static qwen-audio-3.0-tts preset catalog into the local database.
+Voices that already exist (matched by tts_backend + external_id) are skipped.
+
+NOTE: Seeding is optional. The frontend lists Qwen voices on-demand via
+GET /api/v1/voices/qwen/catalog, so this script is useful only if you prefer
+a pre-populated DB.
+"""
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(Path(__file__).parent.parent / ".env")
+
+from artificial_u.integrations.qwen.voice_manager import QwenVoiceManager  # noqa: E402
+from artificial_u.models.core import Voice  # noqa: E402
+from artificial_u.models.repositories.voice import VoiceRepository  # noqa: E402
+
+TTS_BACKEND = "qwen"
+
+
+def seed_qwen_voices(
+    db_url: str | None = None,
+    dry_run: bool = False,
+    logger: logging.Logger | None = None,
+) -> tuple[int, int]:
+    """
+    Seed Qwen preset voices from the static catalog. Idempotent.
+
+    Returns:
+        Tuple of (created_count, skipped_count)
+    """
+    if logger is None:
+        logger = logging.getLogger(__name__)
+
+    raw_voices = QwenVoiceManager(logger=logger).list_voices()
+    logger.info("Loaded %d Qwen preset voices", len(raw_voices))
+
+    effective_url = db_url or os.environ.get("DATABASE_URL")
+    repo = VoiceRepository(db_url=effective_url)
+
+    created = 0
+    skipped = 0
+
+    for v in raw_voices:
+        external_id = v.get("id")
+        if not external_id:
+            continue
+
+        existing = repo.get_by_external_id(TTS_BACKEND, external_id)
+        if existing is not None:
+            logger.debug("Voice already exists: %s (db id=%s)", v.get("name"), existing.id)
+            skipped += 1
+            continue
+
+        if dry_run:
+            logger.info("[DRY RUN] Would create: %s (%s)", v.get("name"), external_id)
+            created += 1
+            continue
+
+        languages = v.get("languages") or []
+        voice = Voice(
+            tts_backend=TTS_BACKEND,
+            external_id=external_id,
+            name=v.get("name") or external_id,
+            gender=v.get("gender"),
+            description=v.get("description"),
+            language="en" if "en" in languages else (str(languages[0]) if languages else None),
+            category="preset",
+        )
+
+        repo.create(voice)
+        logger.info("Created voice: %s (external_id=%s)", voice.name, external_id)
+        created += 1
+
+    return created, skipped
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Seed Qwen (Alibaba) preset voices")
+    parser.add_argument("--db-url", help="Database URL (default: DATABASE_URL env var)")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Report changes without applying them"
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Logging level (default: INFO)",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    logger = logging.getLogger(__name__)
+
+    try:
+        if args.dry_run:
+            logger.info("DRY RUN mode — no changes will be made")
+
+        created, skipped = seed_qwen_voices(db_url=args.db_url, dry_run=args.dry_run, logger=logger)
+        logger.info("Qwen voice seeding complete: %d created, %d skipped", created, skipped)
+
+    except Exception as e:
+        logger.error("Error seeding Qwen voices: %s", e)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/audio/test_speech_processor.py
+++ b/tests/unit/audio/test_speech_processor.py
@@ -330,6 +330,17 @@ class TestSpeechProcessorMistral:
         assert "[walks to the front" in out
 
     @pytest.mark.unit
+    def test_qwen_strips_pause_directions(self, processor):
+        """Qwen path removes pause brackets entirely, no SSML/markup added."""
+        out = processor.normalize_text(
+            "Please consider this. [Pause] Now continue.", backend_name="qwen"
+        )
+        assert "<break" not in out
+        assert "[Pause]" not in out
+        assert "[pause]" not in out
+        assert "Please consider this." in out and "Now continue." in out
+
+    @pytest.mark.unit
     def test_unknown_backend_defaults_to_clean_prose(self, processor):
         """Unknown backends fall back to clean prose (pause directions stripped)."""
         out = processor.normalize_text(

--- a/tests/unit/integrations/test_qwen_tts.py
+++ b/tests/unit/integrations/test_qwen_tts.py
@@ -1,0 +1,179 @@
+"""Unit tests for the Qwen (Alibaba) TTS client, backend adapter, and factory."""
+
+import pytest
+
+from artificial_u.integrations.qwen.tts_client import QwenTTSClient
+from artificial_u.integrations.qwen.voice_manager import (
+    FLASH_MODEL,
+    PLUS_MODEL,
+    QWEN_VOICES,
+    QwenVoiceManager,
+    model_for_voice,
+)
+from artificial_u.integrations.tts.factory import create_tts_backend
+from artificial_u.integrations.tts.qwen_backend import QwenTTSBackend
+
+
+class _FakeSynthesizer:
+    """Stand-in for dashscope SpeechSynthesizer capturing constructor args."""
+
+    last_call = {}
+    audio = b"audio-bytes"
+
+    def __init__(self, model=None, voice=None, format=None, url=None, **kwargs):
+        _FakeSynthesizer.last_call = {
+            "model": model,
+            "voice": voice,
+            "format": format,
+            "url": url,
+        }
+
+    def call(self, text, timeout_millis=None):
+        _FakeSynthesizer.last_call["text"] = text
+        return _FakeSynthesizer.audio
+
+
+@pytest.fixture
+def patch_synthesizer(monkeypatch):
+    import dashscope.audio.tts_v2 as tts_v2
+
+    _FakeSynthesizer.last_call = {}
+    _FakeSynthesizer.audio = b"audio-bytes"
+    monkeypatch.setattr(tts_v2, "SpeechSynthesizer", _FakeSynthesizer)
+    return _FakeSynthesizer
+
+
+@pytest.mark.unit
+def test_client_calls_synthesizer_with_voice_and_url(patch_synthesizer):
+    client = QwenTTSClient(api_key="key-123", wss_url="wss://example.test/api-ws/v1/inference")
+    audio = client.text_to_speech("Hello world", voice_id="loongjohn")
+
+    assert audio == b"audio-bytes"
+    call = patch_synthesizer.last_call
+    assert call["voice"] == "loongjohn"
+    assert call["model"] == FLASH_MODEL
+    assert call["url"] == "wss://example.test/api-ws/v1/inference"
+    assert call["text"] == "Hello world"
+    assert "MP3" in str(call["format"])
+
+    import dashscope
+
+    assert dashscope.api_key == "key-123"
+
+
+@pytest.mark.unit
+def test_client_defaults_voice(patch_synthesizer):
+    client = QwenTTSClient(api_key="key")
+    client.text_to_speech("Hi there everyone")
+    assert patch_synthesizer.last_call["voice"] == QwenTTSClient.DEFAULT_VOICE
+
+
+@pytest.mark.unit
+def test_client_resolves_plus_model_from_voice(patch_synthesizer):
+    client = QwenTTSClient(api_key="key")
+    client.text_to_speech("text", voice_id="longanlingxin")
+    assert patch_synthesizer.last_call["model"] == PLUS_MODEL
+
+
+@pytest.mark.unit
+def test_client_explicit_model_overrides_voice_mapping(patch_synthesizer):
+    client = QwenTTSClient(api_key="key")
+    client.text_to_speech("text", voice_id="longanlingxin", model="custom-model")
+    assert patch_synthesizer.last_call["model"] == "custom-model"
+
+
+@pytest.mark.unit
+def test_client_unknown_voice_falls_back_to_settings_model(patch_synthesizer):
+    client = QwenTTSClient(api_key="key")
+    client.text_to_speech("text", voice_id="some-cloned-voice-id")
+    assert patch_synthesizer.last_call["model"] == client.default_model
+
+
+@pytest.mark.unit
+def test_client_retries_then_raises(monkeypatch):
+    import dashscope.audio.tts_v2 as tts_v2
+
+    monkeypatch.setattr("artificial_u.integrations.qwen.tts_client.time.sleep", lambda *_: None)
+
+    attempts = {"n": 0}
+
+    class _AlwaysFails(_FakeSynthesizer):
+        def call(self, text, timeout_millis=None):
+            attempts["n"] += 1
+            raise ConnectionError("boom")
+
+    monkeypatch.setattr(tts_v2, "SpeechSynthesizer", _AlwaysFails)
+    client = QwenTTSClient(api_key="key")
+    with pytest.raises(ConnectionError):
+        client.text_to_speech("text")
+    assert attempts["n"] == QwenTTSClient.MAX_RETRIES
+
+
+@pytest.mark.unit
+def test_client_raises_on_empty_audio(monkeypatch, patch_synthesizer):
+    monkeypatch.setattr("artificial_u.integrations.qwen.tts_client.time.sleep", lambda *_: None)
+    patch_synthesizer.audio = None
+    client = QwenTTSClient(api_key="key")
+    with pytest.raises(RuntimeError):
+        client.text_to_speech("text")
+
+
+@pytest.mark.unit
+def test_backend_adapter_uses_client(patch_synthesizer):
+    client = QwenTTSClient(api_key="key")
+    backend = QwenTTSBackend(client=client)
+    assert backend.backend_name == "qwen"
+
+    backend.text_to_speech("Some lecture text here", voice_id="loongmary")
+    assert patch_synthesizer.last_call["voice"] == "loongmary"
+
+
+@pytest.mark.unit
+def test_backend_ignores_unrelated_kwargs(patch_synthesizer):
+    """language / voice_settings (used by other backends) must not break Qwen."""
+    client = QwenTTSClient(api_key="key")
+    backend = QwenTTSBackend(client=client)
+    backend.text_to_speech(
+        "text here please", voice_id="loongjohn", language="en", voice_settings={"x": 1}
+    )
+    assert patch_synthesizer.last_call["voice"] == "loongjohn"
+
+
+@pytest.mark.unit
+def test_factory_creates_qwen_backend(patch_synthesizer):
+    backend = create_tts_backend(backend_name="qwen", api_key="key")
+    assert isinstance(backend, QwenTTSBackend)
+    assert backend.backend_name == "qwen"
+
+
+# ---------------------------------------------------------------------------
+# Voice manager (static preset catalog)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_voice_manager_lists_all_voices():
+    voices = QwenVoiceManager().list_voices()
+    assert len(voices) == len(QWEN_VOICES)
+    ids = {v["id"] for v in voices}
+    assert {"loongmary", "loongeva_v3.6", "loongjohn", "longanlingxin"} <= ids
+    # Every preset voice speaks English and has a model assignment
+    for v in voices:
+        assert "en" in v["languages"]
+        assert v["model"] in (FLASH_MODEL, PLUS_MODEL)
+
+
+@pytest.mark.unit
+def test_voice_manager_get_voice():
+    mgr = QwenVoiceManager()
+    john = mgr.get_voice("loongjohn")
+    assert john["gender"] == "male"
+    assert john["model"] == FLASH_MODEL
+    assert mgr.get_voice("nonexistent") is None
+
+
+@pytest.mark.unit
+def test_model_for_voice():
+    assert model_for_voice("longanlufeng") == PLUS_MODEL
+    assert model_for_voice("longpaopao_v3.6") == FLASH_MODEL
+    assert model_for_voice("nonexistent") is None

--- a/tests/unit/integrations/test_qwen_tts.py
+++ b/tests/unit/integrations/test_qwen_tts.py
@@ -156,11 +156,24 @@ def test_voice_manager_lists_all_voices():
     voices = QwenVoiceManager().list_voices()
     assert len(voices) == len(QWEN_VOICES)
     ids = {v["id"] for v in voices}
-    assert {"loongmary", "loongeva_v3.6", "loongjohn", "longanlingxin"} <= ids
-    # Every preset voice speaks English and has a model assignment
+    assert {"loongeva_v3.6", "loongjohn", "longanlingxin", "longanlufeng"} <= ids
+    # No child voices are exposed
+    assert "longjielidou_v3.6" not in ids
+    # Every voice has a valid model and at least one language
     for v in voices:
-        assert "en" in v["languages"]
         assert v["model"] in (FLASH_MODEL, PLUS_MODEL)
+        assert v["languages"]
+
+
+@pytest.mark.unit
+def test_voice_manager_includes_chinese_only_base_voices():
+    """Base (cloned) voices are Mandarin-only and use model-prefixed ids."""
+    mgr = QwenVoiceManager()
+    kai = mgr.get_voice("qwen-audio-3.0-tts-plus-longyinghaikai")
+    assert kai is not None
+    assert kai["languages"] == ["zh"]
+    assert kai["gender"] == "female"
+    assert kai["model"] == PLUS_MODEL
 
 
 @pytest.mark.unit
@@ -169,11 +182,14 @@ def test_voice_manager_get_voice():
     john = mgr.get_voice("loongjohn")
     assert john["gender"] == "male"
     assert john["model"] == FLASH_MODEL
+    lufeng = mgr.get_voice("longanlufeng")
+    assert lufeng["gender"] == "male"
     assert mgr.get_voice("nonexistent") is None
 
 
 @pytest.mark.unit
 def test_model_for_voice():
     assert model_for_voice("longanlufeng") == PLUS_MODEL
-    assert model_for_voice("longpaopao_v3.6") == FLASH_MODEL
+    assert model_for_voice("loongeva_v3.6") == FLASH_MODEL
+    assert model_for_voice("qwen-audio-3.0-tts-plus-longyinghaikai") == PLUS_MODEL
     assert model_for_voice("nonexistent") is None

--- a/tests/unit/test_api_keys.py
+++ b/tests/unit/test_api_keys.py
@@ -28,6 +28,11 @@ def test_environment_variables_are_set():
     # Verify xAI API key
     assert os.environ.get("XAI_API_KEY") == "test_xai_key", "xAI API key not set to test value"
 
+    # Verify Alibaba API key
+    assert (
+        os.environ.get("ALIBABA_API_KEY") == "test_alibaba_key"
+    ), "Alibaba API key not set to test value"
+
     # Verify Google API key
     assert (
         os.environ.get("GOOGLE_API_KEY") == "test_google_key"

--- a/uv.lock
+++ b/uv.lock
@@ -7,12 +7,91 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "aiohappyeyeballs"
+version = "2.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/f4/eec0465c2f67b2664688d0240b3212d5196fd89e741df67ddb81f8d35658/aiohappyeyeballs-2.7.1.tar.gz", hash = "sha256:065665c041c42a5938ed220bdcd7230f22527fbec085e1853d2402c8a3615d9d", size = 24757, upload-time = "2026-07-01T17:11:55.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl", hash = "sha256:9243213661e29250eb41368e5daa826fc017156c3b8a11440826b2e3ed376472", size = 15038, upload-time = "2026-07-01T17:11:54.055Z" },
+]
+
+[[package]]
+name = "aiohttp"
+version = "3.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohappyeyeballs" },
+    { name = "aiosignal" },
+    { name = "attrs" },
+    { name = "frozenlist" },
+    { name = "multidict" },
+    { name = "propcache" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/cc/58f26f118d8099f84e009ce560b9148a3f803e63fa8473b57feb67241875/aiohttp-3.14.2.tar.gz", hash = "sha256:f96821eb2ae2f12b0dfa799eafbf221f5621a9220b457b4744a269a63a5f3a6c", size = 7969860, upload-time = "2026-07-20T19:53:26.881Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/ca/716f720dccc3032e40dc80d0ab2d87a7365270a714976a85bdff73bc7254/aiohttp-3.14.2-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:7719cef2a9dc5e10cd5f476ec1744b25c5ac4da733a9a687d91c42de7d4afe30", size = 508899, upload-time = "2026-07-20T19:51:54.165Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/80/786166589e71b3f3cfce56b414170fe5008462d0bff100bd8837285632f6/aiohttp-3.14.2-cp314-cp314-android_24_x86_64.whl", hash = "sha256:3523ec0cc524a413699f25ec8340f3da368484bc9d5f2a1bf87f233ac20599bf", size = 514722, upload-time = "2026-07-20T19:51:56.208Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/b7/539961cf3e3d3f179ea4b20d456cbdb67d1163c68f2e95bf220438a5afd5/aiohttp-3.14.2-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:c8ab295ee58332ef8fbd62727df90540836dfcf7a61f545d0f2771223b80bf25", size = 488082, upload-time = "2026-07-20T19:51:58.293Z" },
+    { url = "https://files.pythonhosted.org/packages/60/34/c7708eac8edacca9c049a0d6f5fa610005ac3c5634c9ea4751134263bf4e/aiohttp-3.14.2-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:71501bc03ede681401269c569e6f9306c761c1c7d4296675e8e78dd07147070f", size = 494140, upload-time = "2026-07-20T19:52:00.158Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/e1/076b88de36b4ebea62d1c0b225e32bc8a452ee71b2aded82878fa5fa7c9e/aiohttp-3.14.2-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:052478c7d01035d805302db50c2ef626b1c1ba0fe2f6d4a22ae6eaeb43bf2316", size = 502670, upload-time = "2026-07-20T19:52:02.097Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/71/7b7720ffe7e521aaa79a853ebff4c17937f4b5a3a586e9d13b0f38050b35/aiohttp-3.14.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:b0d49be9d9a210b2c993bf32b1eda03f949f7bcda68fc4f718ae8085ae3fb4b8", size = 756406, upload-time = "2026-07-20T19:52:04.082Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9a/c67c7e22fff7d7b17387e718451b30eb89f55df6b8d13d2d7f91daba6505/aiohttp-3.14.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:5fe25c4c44ea5b56fd4512e2065e09384987fc8cc98e41bc8749efe12f653abb", size = 510106, upload-time = "2026-07-20T19:52:06.001Z" },
+    { url = "https://files.pythonhosted.org/packages/27/2a/3caebd640229663263585d4d31898331a3937752f2e1f5ec0af509fa31be/aiohttp-3.14.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7e254b0d636957174a03ca210289e867a62bb9502081e1b44a8c2bb1f6266ecd", size = 512876, upload-time = "2026-07-20T19:52:08.036Z" },
+    { url = "https://files.pythonhosted.org/packages/27/04/86945210e491493f5cd025efe5e6d8fc8a9e8aaf36f943c40f52c34eda7e/aiohttp-3.14.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a6b0ce033d49dd3c6a2566b387e322a9f9029110d67902f0d64571c0fd4b73d8", size = 1750050, upload-time = "2026-07-20T19:52:09.998Z" },
+    { url = "https://files.pythonhosted.org/packages/11/d8/356c62552b4db60af5ad8cddeafa6f837788918201f1b5f2466565c986b5/aiohttp-3.14.2-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:41b5b66b1ac2c48b61e420691eb9741d17d9068f2bc23b5ee3e750faa564bc8f", size = 1707177, upload-time = "2026-07-20T19:52:12.39Z" },
+    { url = "https://files.pythonhosted.org/packages/77/2d/41bb20bed3df1d6dc7fc231ca4ffb72177fd151bf4205a4ade7a93e03501/aiohttp-3.14.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30a5ed81f752f182961237414a3cd0af209c0f74f06d66f66f9fcb8964f4978d", size = 1803795, upload-time = "2026-07-20T19:52:14.705Z" },
+    { url = "https://files.pythonhosted.org/packages/63/21/ad9fe6786a1d2758bcfdae4dbc1d6869ffc7b1e0571530a508de3cdde09b/aiohttp-3.14.2-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1b9251f43d78ff675c0ddfcd53ba61abecc1f74eedc6287bb6657f6c6a033fe7", size = 1876539, upload-time = "2026-07-20T19:52:16.965Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/cb/d213f4fd7af279d82c4b46d30de22db93a01296d77a8d8e535289637da54/aiohttp-3.14.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf7930e83a12801b2e253d41cc8bf5553f61c0cfabef182a72ae13472cc81803", size = 1761130, upload-time = "2026-07-20T19:52:19.127Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4f/0792fe1a24c2b4b506d07350e980b0626c149fe73e68dd37dfb30ed89813/aiohttp-3.14.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:abb33120daba5e5643a757790ece44d638a5a11eb0598312e6e7ec2f1bd1a5a3", size = 1583576, upload-time = "2026-07-20T19:52:21.465Z" },
+    { url = "https://files.pythonhosted.org/packages/46/ad/551c302f534f9cd6105bd16902e69dc64c726aa729127203f47ed4bddb2a/aiohttp-3.14.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:983a68048a48f35ed08aadfcc1ba55de9a121aa91be48a764965c9ec532b94b5", size = 1714139, upload-time = "2026-07-20T19:52:23.636Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cf/a3be8601d2e80ccf7bd4f79807629cede5425d72c02636f06b1ad6a8290a/aiohttp-3.14.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:fef094bfc2f4e991a998af066fc6e3956a409ef799f5cbad2365175357181f2e", size = 1724352, upload-time = "2026-07-20T19:52:26.043Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/b1/6b55f6448b43a3338749f37fc6a14e7ac7dad121d2d585f22c1dd3d324fe/aiohttp-3.14.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2f7ca81d936d820ae479971a6b6214b1b867420b5b58e54a1e7157716a943754", size = 1770749, upload-time = "2026-07-20T19:52:28.467Z" },
+    { url = "https://files.pythonhosted.org/packages/39/58/b3f1cf6af47fa0b0d51c6e2b98b2bf0326b44a932d74915f3c0874413ea8/aiohttp-3.14.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:da4f142fa078fedbdb3f88d0542ad9315656224e167502ae274cbba818b90c90", size = 1577547, upload-time = "2026-07-20T19:52:30.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e2/1d79f1ab35593d70dabed98936ae842ac90d12847c9a62bba4a19d6005a4/aiohttp-3.14.2-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:3d4238e50a378f5ac69a1e0162715c676bd082dede2e5c4f67ca7fd0014cb09d", size = 1781840, upload-time = "2026-07-20T19:52:33.021Z" },
+    { url = "https://files.pythonhosted.org/packages/01/73/770be856c6fc861563999081a5fe2d44e16b4255f5fd94b2217a2349ca65/aiohttp-3.14.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:03330676d8caa28bb33fa7104b0d542d9aac93350abcd91bf68e64abd531c320", size = 1745757, upload-time = "2026-07-20T19:52:35.541Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/0b/861fdbe3ff90b503a4d0a12276623f4afbe54c237ca876fc560125c270a3/aiohttp-3.14.2-cp314-cp314-win32.whl", hash = "sha256:43387429e4f2ec4047aaf9f935db003d4aa1268ea9021164877fd6b012b6396a", size = 455863, upload-time = "2026-07-20T19:52:37.634Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/03/cc8234d0f06fe4b0e1777c7ed313cc9014f078f72a9a0cbdc144965d1bd7/aiohttp-3.14.2-cp314-cp314-win_amd64.whl", hash = "sha256:e3a6302f47518dbf2ffd3cd518f02a1fbf53f85ffeed41a224fa4a6f6a62673b", size = 480986, upload-time = "2026-07-20T19:52:39.665Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b0/ae17dd629e22160f453b9041a4aee80a8a917ba2f44d5b3e252cc501ed2c/aiohttp-3.14.2-cp314-cp314-win_arm64.whl", hash = "sha256:8d1f3802887f0e0dc07387a081dca3ad0b5758e32bdf5fb619b12ac22b8e9b56", size = 453588, upload-time = "2026-07-20T19:52:41.634Z" },
+    { url = "https://files.pythonhosted.org/packages/30/54/4bbcc00f04dbc380103ee669a56df30dea127c3686c8dc2ab86b05a1387b/aiohttp-3.14.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9094262ae4f2902c7291c14ba915960db5567276690ef9195cdefe8b7cbb3acb", size = 791337, upload-time = "2026-07-20T19:52:43.821Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/37/4f95edc1488580c63c0b5baaef429afbacadc7ccd9c47431cdcce90d9e5a/aiohttp-3.14.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:165b0dcc65960ffc9c99aa4ba1c3c76dbc7a34845c3c23a0bd3fbf33b3d12569", size = 526335, upload-time = "2026-07-20T19:52:45.903Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/ed/1d7ae73764d135638797a427cb637ae3d98f1fd61208c25891a9f26cdd67/aiohttp-3.14.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f518d75c03cd3f7f125eca1baadb56f8b94db94602278d2d0d19af6e177650a7", size = 532102, upload-time = "2026-07-20T19:52:47.994Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/12/da9816eee0d81506560259e7c0af93a4aa7df98acd0fe276958abd42d7c3/aiohttp-3.14.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b937d7864ca68f1e8a1c3a4eb2bac1de86a992f86d36492da10a135a482fab6", size = 1922727, upload-time = "2026-07-20T19:52:50.224Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/b9/d7ccbcde223a72c7b8f3458bdb08c2bacf5fc268a1fdd5cc29861eb0e4e2/aiohttp-3.14.2-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b155df7f572c73c6c4108b67be302c8639b96ae56fb02787eeae8cad0a1baf26", size = 1787202, upload-time = "2026-07-20T19:52:52.825Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/7c/39174069b7df18ea22b23a0fa9abffe4c091f0f86d53af83ddcbb5f44c8f/aiohttp-3.14.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0bfea68a48c8071d49aabdf5cd9a6939dcb246db65730e8dc76295fe02f7c73c", size = 1912574, upload-time = "2026-07-20T19:52:55.007Z" },
+    { url = "https://files.pythonhosted.org/packages/21/ff/bd2b7473510caf352aef3f52a3d4fe10184ec22747df74ab658b4402020f/aiohttp-3.14.2-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8241ee6c7fff3ebb1e6b237bccc1d90b46d07c06cf978e9f2ecad43e29dac67a", size = 2005478, upload-time = "2026-07-20T19:52:57.401Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/ee/db26af0acc994350b653b3a73dddf9ee9886bf2fdb68b23fc98705e76442/aiohttp-3.14.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ec64d1c4605d689ed537ba1e572138e2d4ff603a0cb2bbbfe61d4552c73d19e1", size = 1879709, upload-time = "2026-07-20T19:52:59.778Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/4d/592451fd40edca73fcb099d8718668cea36dc1dde873dd0f8e91a4081051/aiohttp-3.14.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0fb26fcc5ebf765095fe0c6ab7501574d3108c57fca9a0d462be15a65c9deb8d", size = 1675699, upload-time = "2026-07-20T19:53:02.11Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/3e/c1ce4aa13fd1f910e437684843ea6cf6e0041f91d89a1b0389dce247ee59/aiohttp-3.14.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ef710fbb770aefa4def5484eeddb606e70ab3492aa37390def61b35652f6820a", size = 1843542, upload-time = "2026-07-20T19:53:04.385Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/3f9e22fda714cc38ef558166ff3326cd2f6f65c33da92ba00e3641cbea54/aiohttp-3.14.2-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:d813f54560b9e5bce170fff7b0adde54d88253928e4add447c36792f27f92125", size = 1827505, upload-time = "2026-07-20T19:53:07.072Z" },
+    { url = "https://files.pythonhosted.org/packages/37/9d/260c7b8a25c7cd74bee63ce957556a2d25839a321e9107a089d4da3a51af/aiohttp-3.14.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:1aa4f3b44563a88da4407cef8a13438e9e386967720a826a10a633493f69208f", size = 1853751, upload-time = "2026-07-20T19:53:10.012Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d6/7c3cfa191e666bf7b48b4346815900b35b85b43ffff783fd0be52e45fe09/aiohttp-3.14.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:4610638d3135afaefadf179bffd1bbf3434d3dc7a5d0a4c4219b99fa976e944d", size = 1668850, upload-time = "2026-07-20T19:53:12.362Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/af/d9b8353aee9506dace04ca22c3c4e93b7375d9343c4780c8b512972fc6f9/aiohttp-3.14.2-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:6e30743bd3ab6ad98e9abbad6ccb39c52bcf6f11f9e3d4b6df97afffe8df53f3", size = 1883642, upload-time = "2026-07-20T19:53:14.664Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/29/ed64c0a013322570a02e5b0e359df2cfd30ae58ba045748dc78175f15826/aiohttp-3.14.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:68a6f7cd8d2c70869a2a5fe97a16e86a4e13a6ed6f0d9e6029aef7573e344cd6", size = 1844092, upload-time = "2026-07-20T19:53:16.995Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/74/ce6f229510fdd46ee7365fbb759ffaa3004e0bcc59fbd0ec51d8a8efc775/aiohttp-3.14.2-cp314-cp314t-win32.whl", hash = "sha256:205181d896f73436ac60cf6644e545544c759ab1c3ec8c34cc1e044689611361", size = 474098, upload-time = "2026-07-20T19:53:19.645Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4c/877c07a6d97a1a0e5e25a06bab76dd7449b533ff8bb6c281c5af8b09c8d9/aiohttp-3.14.2-cp314-cp314t-win_amd64.whl", hash = "sha256:312d414c294a1e26aa12888e8fd37cd2e1131e9c48ddcf2a4c6b590290d52a49", size = 500480, upload-time = "2026-07-20T19:53:22.227Z" },
+    { url = "https://files.pythonhosted.org/packages/42/d8/d4c74bb7990da2ee6116fe262ace41cf376ebc6b0bda694c77eeaab5a509/aiohttp-3.14.2-cp314-cp314t-win_arm64.whl", hash = "sha256:63b840c03979732ec92e570f0bd6beb6311e2b5d19cacbfcd8cc7f6dd2693900", size = 469248, upload-time = "2026-07-20T19:53:24.622Z" },
+]
+
+[[package]]
 name = "aiolimiter"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/23/b52debf471f7a1e42e362d959a3982bdcb4fe13a5d46e63d28868807a79c/aiolimiter-1.2.1.tar.gz", hash = "sha256:e02a37ea1a855d9e832252a105420ad4d15011505512a1a1d814647451b5cca9", size = 7185, upload-time = "2024-12-08T15:31:51.496Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/ba/df6e8e1045aebc4778d19b8a3a9bc1808adb1619ba94ca354d9ba17d86c3/aiolimiter-1.2.1-py3-none-any.whl", hash = "sha256:d3f249e9059a20badcb56b61601a83556133655c11d1eb3dd3e04ff069e5f3c7", size = 6711, upload-time = "2024-12-08T15:31:49.874Z" },
+]
+
+[[package]]
+name = "aiosignal"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "frozenlist" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
 ]
 
 [[package]]
@@ -88,6 +167,7 @@ dependencies = [
     { name = "anthropic" },
     { name = "boto3" },
     { name = "click" },
+    { name = "dashscope" },
     { name = "elevenlabs" },
     { name = "fastapi" },
     { name = "google-api-core" },
@@ -140,6 +220,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.86.0" },
     { name = "boto3", specifier = ">=1.42.73" },
     { name = "click", specifier = ">=8.2.0" },
+    { name = "dashscope", specifier = ">=1.26.4" },
     { name = "elevenlabs", specifier = ">=2.39.0" },
     { name = "fastapi", specifier = ">=0.135.1" },
     { name = "google-api-core", specifier = ">=2.28.1" },
@@ -593,6 +674,25 @@ wheels = [
 ]
 
 [[package]]
+name = "dashscope"
+version = "1.26.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "certifi" },
+    { name = "cryptography" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "typer" },
+    { name = "websocket-client" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/20/4dd714b5d015f3f18bce69916d3ed3b6b0af5952664733f2c9c5ce57efbf/dashscope-1.26.4-py3-none-any.whl", hash = "sha256:d56db91aecd4d981f2fdbdf526a2646a508c2f2b45347ed451cff6166ac17e3d", size = 1526000, upload-time = "2026-07-17T08:51:55.928Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -694,6 +794,47 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9b/af/fbfe3c4b5a657d79e5c47a2827a362f9e1b763336a52f926126aa6dc7123/flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872", size = 48326, upload-time = "2025-06-20T19:31:35.838Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e", size = 57922, upload-time = "2025-06-20T19:31:34.425Z" },
+]
+
+[[package]]
+name = "frozenlist"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/c8/85da824b7e7b9b6e7f7705b2ecaf9591ba6f79c1177f324c2735e41d36a2/frozenlist-1.8.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cee686f1f4cadeb2136007ddedd0aaf928ab95216e7691c63e50a8ec066336d0", size = 86127, upload-time = "2025-10-06T05:37:08.438Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e8/a1185e236ec66c20afd72399522f142c3724c785789255202d27ae992818/frozenlist-1.8.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:119fb2a1bd47307e899c2fac7f28e85b9a543864df47aa7ec9d3c1b4545f096f", size = 49698, upload-time = "2025-10-06T05:37:09.48Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4970ece02dbc8c3a92fcc5228e36a3e933a01a999f7094ff7c23fbd2beeaa67c", size = 49749, upload-time = "2025-10-06T05:37:10.569Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:cba69cb73723c3f329622e34bdbf5ce1f80c21c290ff04256cff1cd3c2036ed2", size = 231298, upload-time = "2025-10-06T05:37:11.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/3b/d9b1e0b0eed36e70477ffb8360c49c85c8ca8ef9700a4e6711f39a6e8b45/frozenlist-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:778a11b15673f6f1df23d9586f83c4846c471a8af693a22e066508b77d201ec8", size = 232015, upload-time = "2025-10-06T05:37:13.194Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/94/be719d2766c1138148564a3960fc2c06eb688da592bdc25adcf856101be7/frozenlist-1.8.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0325024fe97f94c41c08872db482cf8ac4800d80e79222c6b0b7b162d5b13686", size = 225038, upload-time = "2025-10-06T05:37:14.577Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/09/6712b6c5465f083f52f50cf74167b92d4ea2f50e46a9eea0523d658454ae/frozenlist-1.8.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:97260ff46b207a82a7567b581ab4190bd4dfa09f4db8a8b49d1a958f6aa4940e", size = 240130, upload-time = "2025-10-06T05:37:15.781Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d4/cd065cdcf21550b54f3ce6a22e143ac9e4836ca42a0de1022da8498eac89/frozenlist-1.8.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:54b2077180eb7f83dd52c40b2750d0a9f175e06a42e3213ce047219de902717a", size = 242845, upload-time = "2025-10-06T05:37:17.037Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c3/f57a5c8c70cd1ead3d5d5f776f89d33110b1addae0ab010ad774d9a44fb9/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2f05983daecab868a31e1da44462873306d3cbfd76d1f0b5b69c473d21dbb128", size = 229131, upload-time = "2025-10-06T05:37:18.221Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/52/232476fe9cb64f0742f3fde2b7d26c1dac18b6d62071c74d4ded55e0ef94/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:33f48f51a446114bc5d251fb2954ab0164d5be02ad3382abcbfe07e2531d650f", size = 240542, upload-time = "2025-10-06T05:37:19.771Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/85/07bf3f5d0fb5414aee5f47d33c6f5c77bfe49aac680bfece33d4fdf6a246/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:154e55ec0655291b5dd1b8731c637ecdb50975a2ae70c606d100750a540082f7", size = 237308, upload-time = "2025-10-06T05:37:20.969Z" },
+    { url = "https://files.pythonhosted.org/packages/11/99/ae3a33d5befd41ac0ca2cc7fd3aa707c9c324de2e89db0e0f45db9a64c26/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:4314debad13beb564b708b4a496020e5306c7333fa9a3ab90374169a20ffab30", size = 238210, upload-time = "2025-10-06T05:37:22.252Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/60/b1d2da22f4970e7a155f0adde9b1435712ece01b3cd45ba63702aea33938/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:073f8bf8becba60aa931eb3bc420b217bb7d5b8f4750e6f8b3be7f3da85d38b7", size = 231972, upload-time = "2025-10-06T05:37:23.5Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ab/945b2f32de889993b9c9133216c068b7fcf257d8595a0ac420ac8677cab0/frozenlist-1.8.0-cp314-cp314-win32.whl", hash = "sha256:bac9c42ba2ac65ddc115d930c78d24ab8d4f465fd3fc473cdedfccadb9429806", size = 40536, upload-time = "2025-10-06T05:37:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/59/ad/9caa9b9c836d9ad6f067157a531ac48b7d36499f5036d4141ce78c230b1b/frozenlist-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:3e0761f4d1a44f1d1a47996511752cf3dcec5bbdd9cc2b4fe595caf97754b7a0", size = 44330, upload-time = "2025-10-06T05:37:26.928Z" },
+    { url = "https://files.pythonhosted.org/packages/82/13/e6950121764f2676f43534c555249f57030150260aee9dcf7d64efda11dd/frozenlist-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:d1eaff1d00c7751b7c6662e9c5ba6eb2c17a2306ba5e2a37f24ddf3cc953402b", size = 40627, upload-time = "2025-10-06T05:37:28.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/c7/43200656ecc4e02d3f8bc248df68256cd9572b3f0017f0a0c4e93440ae23/frozenlist-1.8.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:d3bb933317c52d7ea5004a1c442eef86f426886fba134ef8cf4226ea6ee1821d", size = 89238, upload-time = "2025-10-06T05:37:29.373Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/29/55c5f0689b9c0fb765055629f472c0de484dcaf0acee2f7707266ae3583c/frozenlist-1.8.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8009897cdef112072f93a0efdce29cd819e717fd2f649ee3016efd3cd885a7ed", size = 50738, upload-time = "2025-10-06T05:37:30.792Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7d/b7282a445956506fa11da8c2db7d276adcbf2b17d8bb8407a47685263f90/frozenlist-1.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2c5dcbbc55383e5883246d11fd179782a9d07a986c40f49abe89ddf865913930", size = 51739, upload-time = "2025-10-06T05:37:32.127Z" },
+    { url = "https://files.pythonhosted.org/packages/62/1c/3d8622e60d0b767a5510d1d3cf21065b9db874696a51ea6d7a43180a259c/frozenlist-1.8.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:39ecbc32f1390387d2aa4f5a995e465e9e2f79ba3adcac92d68e3e0afae6657c", size = 284186, upload-time = "2025-10-06T05:37:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/14/aa36d5f85a89679a85a1d44cd7a6657e0b1c75f61e7cad987b203d2daca8/frozenlist-1.8.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92db2bf818d5cc8d9c1f1fc56b897662e24ea5adb36ad1f1d82875bd64e03c24", size = 292196, upload-time = "2025-10-06T05:37:36.107Z" },
+    { url = "https://files.pythonhosted.org/packages/05/23/6bde59eb55abd407d34f77d39a5126fb7b4f109a3f611d3929f14b700c66/frozenlist-1.8.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2dc43a022e555de94c3b68a4ef0b11c4f747d12c024a520c7101709a2144fb37", size = 273830, upload-time = "2025-10-06T05:37:37.663Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3f/22cff331bfad7a8afa616289000ba793347fcd7bc275f3b28ecea2a27909/frozenlist-1.8.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cb89a7f2de3602cfed448095bab3f178399646ab7c61454315089787df07733a", size = 294289, upload-time = "2025-10-06T05:37:39.261Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/89/5b057c799de4838b6c69aa82b79705f2027615e01be996d2486a69ca99c4/frozenlist-1.8.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:33139dc858c580ea50e7e60a1b0ea003efa1fd42e6ec7fdbad78fff65fad2fd2", size = 300318, upload-time = "2025-10-06T05:37:43.213Z" },
+    { url = "https://files.pythonhosted.org/packages/30/de/2c22ab3eb2a8af6d69dc799e48455813bab3690c760de58e1bf43b36da3e/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:168c0969a329b416119507ba30b9ea13688fafffac1b7822802537569a1cb0ef", size = 282814, upload-time = "2025-10-06T05:37:45.337Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f7/970141a6a8dbd7f556d94977858cfb36fa9b66e0892c6dd780d2219d8cd8/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:28bd570e8e189d7f7b001966435f9dac6718324b5be2990ac496cf1ea9ddb7fe", size = 291762, upload-time = "2025-10-06T05:37:46.657Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/15/ca1adae83a719f82df9116d66f5bb28bb95557b3951903d39135620ef157/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b2a095d45c5d46e5e79ba1e5b9cb787f541a8dee0433836cea4b96a2c439dcd8", size = 289470, upload-time = "2025-10-06T05:37:47.946Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/83/dca6dc53bf657d371fbc88ddeb21b79891e747189c5de990b9dfff2ccba1/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:eab8145831a0d56ec9c4139b6c3e594c7a83c2c8be25d5bcf2d86136a532287a", size = 289042, upload-time = "2025-10-06T05:37:49.499Z" },
+    { url = "https://files.pythonhosted.org/packages/96/52/abddd34ca99be142f354398700536c5bd315880ed0a213812bc491cff5e4/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:974b28cf63cc99dfb2188d8d222bc6843656188164848c4f679e63dae4b0708e", size = 283148, upload-time = "2025-10-06T05:37:50.745Z" },
+    { url = "https://files.pythonhosted.org/packages/af/d3/76bd4ed4317e7119c2b7f57c3f6934aba26d277acc6309f873341640e21f/frozenlist-1.8.0-cp314-cp314t-win32.whl", hash = "sha256:342c97bf697ac5480c0a7ec73cd700ecfa5a8a40ac923bd035484616efecc2df", size = 44676, upload-time = "2025-10-06T05:37:52.222Z" },
+    { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
 ]
 
 [[package]]
@@ -879,6 +1020,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
 ]
 
 [[package]]
@@ -1127,6 +1277,51 @@ wheels = [
 ]
 
 [[package]]
+name = "multidict"
+version = "6.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/cc/db74228a8be41884a567e88a62fd589a913708fcf180d029898c17a9a371/multidict-6.7.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8f333ec9c5eb1b7105e3b84b53141e66ca05a19a605368c55450b6ba208cb9ee", size = 75190, upload-time = "2026-01-26T02:45:10.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/22/492f2246bb5b534abd44804292e81eeaf835388901f0c574bac4eeec73c5/multidict-6.7.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:a407f13c188f804c759fc6a9f88286a565c242a76b27626594c133b82883b5c2", size = 44486, upload-time = "2026-01-26T02:45:11.938Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/4f/733c48f270565d78b4544f2baddc2fb2a245e5a8640254b12c36ac7ac68e/multidict-6.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0e161ddf326db5577c3a4cc2d8648f81456e8a20d40415541587a71620d7a7d1", size = 43219, upload-time = "2026-01-26T02:45:14.346Z" },
+    { url = "https://files.pythonhosted.org/packages/24/bb/2c0c2287963f4259c85e8bcbba9182ced8d7fca65c780c38e99e61629d11/multidict-6.7.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1e3a8bb24342a8201d178c3b4984c26ba81a577c80d4d525727427460a50c22d", size = 245132, upload-time = "2026-01-26T02:45:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f9/44d4b3064c65079d2467888794dea218d1601898ac50222ab8a9a8094460/multidict-6.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97231140a50f5d447d3164f994b86a0bed7cd016e2682f8650d6a9158e14fd31", size = 252420, upload-time = "2026-01-26T02:45:17.293Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/78f7275e73fa17b24c9a51b0bd9d73ba64bb32d0ed51b02a746eb876abe7/multidict-6.7.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6b10359683bd8806a200fd2909e7c8ca3a7b24ec1d8132e483d58e791d881048", size = 233510, upload-time = "2026-01-26T02:45:19.356Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/25/8167187f62ae3cbd52da7893f58cb036b47ea3fb67138787c76800158982/multidict-6.7.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:283ddac99f7ac25a4acadbf004cb5ae34480bbeb063520f70ce397b281859362", size = 264094, upload-time = "2026-01-26T02:45:20.834Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/e7/69a3a83b7b030cf283fb06ce074a05a02322359783424d7edf0f15fe5022/multidict-6.7.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:538cec1e18c067d0e6103aa9a74f9e832904c957adc260e61cd9d8cf0c3b3d37", size = 260786, upload-time = "2026-01-26T02:45:22.818Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/3b/8ec5074bcfc450fe84273713b4b0a0dd47c0249358f5d82eb8104ffe2520/multidict-6.7.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7eee46ccb30ff48a1e35bb818cc90846c6be2b68240e42a78599166722cea709", size = 248483, upload-time = "2026-01-26T02:45:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5a/d5a99e3acbca0e29c5d9cba8f92ceb15dce78bab963b308ae692981e3a5d/multidict-6.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fa263a02f4f2dd2d11a7b1bb4362aa7cb1049f84a9235d31adf63f30143469a0", size = 248403, upload-time = "2026-01-26T02:45:25.982Z" },
+    { url = "https://files.pythonhosted.org/packages/35/48/e58cd31f6c7d5102f2a4bf89f96b9cf7e00b6c6f3d04ecc44417c00a5a3c/multidict-6.7.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:2e1425e2f99ec5bd36c15a01b690a1a2456209c5deed58f95469ffb46039ccbb", size = 240315, upload-time = "2026-01-26T02:45:27.487Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/1cd210229559cb90b6786c30676bb0c58249ff42f942765f88793b41fdce/multidict-6.7.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:497394b3239fc6f0e13a78a3e1b61296e72bf1c5f94b4c4eb80b265c37a131cd", size = 245528, upload-time = "2026-01-26T02:45:28.991Z" },
+    { url = "https://files.pythonhosted.org/packages/64/f2/6e1107d226278c876c783056b7db43d800bb64c6131cec9c8dfb6903698e/multidict-6.7.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:233b398c29d3f1b9676b4b6f75c518a06fcb2ea0b925119fb2c1bc35c05e1601", size = 258784, upload-time = "2026-01-26T02:45:30.503Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/c1/11f664f14d525e4a1b5327a82d4de61a1db604ab34c6603bb3c2cc63ad34/multidict-6.7.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:93b1818e4a6e0930454f0f2af7dfce69307ca03cdcfb3739bf4d91241967b6c1", size = 251980, upload-time = "2026-01-26T02:45:32.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/9f/75a9ac888121d0c5bbd4ecf4eead45668b1766f6baabfb3b7f66a410e231/multidict-6.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f33dc2a3abe9249ea5d8360f969ec7f4142e7ac45ee7014d8f8d5acddf178b7b", size = 243602, upload-time = "2026-01-26T02:45:34.043Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e7/50bf7b004cc8525d80dbbbedfdc7aed3e4c323810890be4413e589074032/multidict-6.7.1-cp314-cp314-win32.whl", hash = "sha256:3ab8b9d8b75aef9df299595d5388b14530839f6422333357af1339443cff777d", size = 40930, upload-time = "2026-01-26T02:45:36.278Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/bf/52f25716bbe93745595800f36fb17b73711f14da59ed0bb2eba141bc9f0f/multidict-6.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:5e01429a929600e7dab7b166062d9bb54a5eed752384c7384c968c2afab8f50f", size = 45074, upload-time = "2026-01-26T02:45:37.546Z" },
+    { url = "https://files.pythonhosted.org/packages/97/ab/22803b03285fa3a525f48217963da3a65ae40f6a1b6f6cf2768879e208f9/multidict-6.7.1-cp314-cp314-win_arm64.whl", hash = "sha256:4885cb0e817aef5d00a2e8451d4665c1808378dc27c2705f1bf4ef8505c0d2e5", size = 42471, upload-time = "2026-01-26T02:45:38.889Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/6d/f9293baa6146ba9507e360ea0292b6422b016907c393e2f63fc40ab7b7b5/multidict-6.7.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0458c978acd8e6ea53c81eefaddbbee9c6c5e591f41b3f5e8e194780fe026581", size = 82401, upload-time = "2026-01-26T02:45:40.254Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/53b5494738d83558d87c3c71a486504d8373421c3e0dbb6d0db48ad42ee0/multidict-6.7.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c0abd12629b0af3cf590982c0b413b1e7395cd4ec026f30986818ab95bfaa94a", size = 48143, upload-time = "2026-01-26T02:45:41.635Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e8/5284c53310dcdc99ce5d66563f6e5773531a9b9fe9ec7a615e9bc306b05f/multidict-6.7.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:14525a5f61d7d0c94b368a42cff4c9a4e7ba2d52e2672a7b23d84dc86fb02b0c", size = 46507, upload-time = "2026-01-26T02:45:42.99Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/fc/6800d0e5b3875568b4083ecf5f310dcf91d86d52573160834fb4bfcf5e4f/multidict-6.7.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:17307b22c217b4cf05033dabefe68255a534d637c6c9b0cc8382718f87be4262", size = 239358, upload-time = "2026-01-26T02:45:44.376Z" },
+    { url = "https://files.pythonhosted.org/packages/41/75/4ad0973179361cdf3a113905e6e088173198349131be2b390f9fa4da5fc6/multidict-6.7.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a7e590ff876a3eaf1c02a4dfe0724b6e69a9e9de6d8f556816f29c496046e59", size = 246884, upload-time = "2026-01-26T02:45:47.167Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/9c/095bb28b5da139bd41fb9a5d5caff412584f377914bd8787c2aa98717130/multidict-6.7.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:5fa6a95dfee63893d80a34758cd0e0c118a30b8dcb46372bf75106c591b77889", size = 225878, upload-time = "2026-01-26T02:45:48.698Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d0/c0a72000243756e8f5a277b6b514fa005f2c73d481b7d9e47cd4568aa2e4/multidict-6.7.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a0543217a6a017692aa6ae5cc39adb75e587af0f3a82288b1492eb73dd6cc2a4", size = 253542, upload-time = "2026-01-26T02:45:50.164Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/6b/f69da15289e384ecf2a68837ec8b5ad8c33e973aa18b266f50fe55f24b8c/multidict-6.7.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f99fe611c312b3c1c0ace793f92464d8cd263cc3b26b5721950d977b006b6c4d", size = 252403, upload-time = "2026-01-26T02:45:51.779Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/76/b9669547afa5a1a25cd93eaca91c0da1c095b06b6d2d8ec25b713588d3a1/multidict-6.7.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9004d8386d133b7e6135679424c91b0b854d2d164af6ea3f289f8f2761064609", size = 244889, upload-time = "2026-01-26T02:45:53.27Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/a9/a50d2669e506dad33cfc45b5d574a205587b7b8a5f426f2fbb2e90882588/multidict-6.7.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e628ef0e6859ffd8273c69412a2465c4be4a9517d07261b33334b5ec6f3c7489", size = 241982, upload-time = "2026-01-26T02:45:54.919Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/bb/1609558ad8b456b4827d3c5a5b775c93b87878fd3117ed3db3423dfbce1b/multidict-6.7.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:841189848ba629c3552035a6a7f5bf3b02eb304e9fea7492ca220a8eda6b0e5c", size = 232415, upload-time = "2026-01-26T02:45:56.981Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/59/6f61039d2aa9261871e03ab9dc058a550d240f25859b05b67fd70f80d4b3/multidict-6.7.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:ce1bbd7d780bb5a0da032e095c951f7014d6b0a205f8318308140f1a6aba159e", size = 240337, upload-time = "2026-01-26T02:45:58.698Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/29/fdc6a43c203890dc2ae9249971ecd0c41deaedfe00d25cb6564b2edd99eb/multidict-6.7.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b26684587228afed0d50cf804cc71062cc9c1cdf55051c4c6345d372947b268c", size = 248788, upload-time = "2026-01-26T02:46:00.862Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/14/a153a06101323e4cf086ecee3faadba52ff71633d471f9685c42e3736163/multidict-6.7.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:9f9af11306994335398293f9958071019e3ab95e9a707dc1383a35613f6abcb9", size = 242842, upload-time = "2026-01-26T02:46:02.824Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5f/604ae839e64a4a6efc80db94465348d3b328ee955e37acb24badbcd24d83/multidict-6.7.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b4938326284c4f1224178a560987b6cf8b4d38458b113d9b8c1db1a836e640a2", size = 240237, upload-time = "2026-01-26T02:46:05.898Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/c3a5187bf66f6fb546ff4ab8fb5a077cbdd832d7b1908d4365c7f74a1917/multidict-6.7.1-cp314-cp314t-win32.whl", hash = "sha256:98655c737850c064a65e006a3df7c997cd3b220be4ec8fe26215760b9697d4d7", size = 48008, upload-time = "2026-01-26T02:46:07.468Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/f7/addf1087b860ac60e6f382240f64fb99f8bfb532bb06f7c542b83c29ca61/multidict-6.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:497bde6223c212ba11d462853cfa4f0ae6ef97465033e7dc9940cdb3ab5b48e5", size = 53542, upload-time = "2026-01-26T02:46:08.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/81/4629d0aa32302ef7b2ec65c75a728cc5ff4fa410c50096174c1632e70b3e/multidict-6.7.1-cp314-cp314t-win_arm64.whl", hash = "sha256:2bbd113e0d4af5db41d5ebfe9ccaff89de2120578164f86a5d17d5a576d1e5b2", size = 44719, upload-time = "2026-01-26T02:46:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
 name = "mutagen"
 version = "1.48.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1329,6 +1524,49 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/25/3a/ddb78f32a0814e66b18a099377a106a2dcdce92d86a034d69d65df9b256e/pre_commit-4.6.1.tar.gz", hash = "sha256:03e809865c7d178b9979d06c761fcbfe6808fdaded8581a745bb110e52050421", size = 198646, upload-time = "2026-07-21T20:56:58.225Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/49/bc925106abcdac498074f2cbe6137e94e09f418dd2b7775df5b577dc0313/pre_commit-4.6.1-py2.py3-none-any.whl", hash = "sha256:0e3b2942510d1fb34eec167a3ec57331bf8442122f1153a9fb8b58f5c49b2717", size = 226186, upload-time = "2026-07-21T20:56:57.064Z" },
+]
+
+[[package]]
+name = "propcache"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/44/c87281c333769159c50594f22610f77398a47ccbfbbf23074e744e86f87c/propcache-0.5.2.tar.gz", hash = "sha256:01c4fc7480cd0598bb4b57022df55b9ca296da7fc5a8760bd8451a7e63a7d427", size = 50208, upload-time = "2026-05-08T21:02:12.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/ea/23ee535d90ce8bcc465a3028eb3cc0ce3bd1005f4bb27710b30587de798d/propcache-0.5.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:46088abff4cba581dea21ae0467a480526cb25aa5f3c269e909f800328bc3999", size = 94662, upload-time = "2026-05-08T21:01:22.683Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/06/c5a52f419b5d8972f8d46a7577476090d8e3263ff589ce40b5ca4968d5be/propcache-0.5.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fc88b26f08d634f7bc819a7852e5214f5802641ab8d9fd5326892292eee1993e", size = 53928, upload-time = "2026-05-08T21:01:23.986Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b1/4260d67d6bd85e58a66b72d54ce15d5de789b6f3870cc6bedf8ff9667401/propcache-0.5.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:97797ebb098e670a2f92dd66f32897e30d7615b14e7f59711de23e30a9072539", size = 54650, upload-time = "2026-05-08T21:01:25.305Z" },
+    { url = "https://files.pythonhosted.org/packages/70/06/2f46c318e3307cd7a6a7481def374ce838c0fe20084b39dd54b0879d0e99/propcache-0.5.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba57fffe4ac99c5d30076161b5866336d97600769bad35cc68f7774b15298a4e", size = 59912, upload-time = "2026-05-08T21:01:26.545Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/29/fe1aebec2ce57ab985a9c382bded1124431f85078113aa222c5d278430d4/propcache-0.5.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:583c19759d9eec1e5b69e2fbef36a7d9c326041be9746cb822d335c8cedc2979", size = 63300, upload-time = "2026-05-08T21:01:27.937Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/18/2334b26768b6c82be8c69e83671b767d5ef426aa09b0cba6c2ea47816774/propcache-0.5.2-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d0326e2e5e1f3163fa306c834e48e8d490e5fae607a097a40c0648109b47ba80", size = 64208, upload-time = "2026-05-08T21:01:29.484Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/76/7f1bfd6afff4c5e38e36a3c6d68eb5f4b7311ea80baf693db78d95b603c4/propcache-0.5.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e00820e192c8dbebcafb383ebbf99030895f09905e7a0eb2e0340a0bcc2bc825", size = 61633, upload-time = "2026-05-08T21:01:31.068Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/46/b3ff8aba2b4953a3e50de2cf72f1b5748b8eca93b15f3dc2c84339084c09/propcache-0.5.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c66afea89b1e43725731d2004732a046fe6fe955d51f952c3e95a7314a284a39", size = 61724, upload-time = "2026-05-08T21:01:32.374Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/01/814cfcafbcff954f94c01cf30e097ddc88a076b5440fbcf4570753437d40/propcache-0.5.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d4dc37dec6c6cdad0b57881a5658fd14fbf53e333b1a86cf86559f190e1d9ec4", size = 60069, upload-time = "2026-05-08T21:01:33.67Z" },
+    { url = "https://files.pythonhosted.org/packages/da/68/5c6f7622d510cc666a300687e06fd060c1a43361c0c9b20d284f06d8096a/propcache-0.5.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:5570dbcc97571c15f68068e529c92715a12f8d54030e272d264b377e22bd17a5", size = 57099, upload-time = "2026-05-08T21:01:34.915Z" },
+    { url = "https://files.pythonhosted.org/packages/55/27/9cb0b4c679124085327957d42521c99dba04c88c90c3e55a6f0b633ebccc/propcache-0.5.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f814362777a9f841adddb200ecdf8f5cb1e5a3c4b7a86378edbd6ccb26edd702", size = 63391, upload-time = "2026-05-08T21:01:36.231Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/9d/7258aaa5bdf60fc6f27591eef6fe52768cb0beda7140be477c8b12c9794a/propcache-0.5.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:196913dea116aeb5a2ba95af4ddcb7ea85559ae07d8eee8751688310d09168c3", size = 61626, upload-time = "2026-05-08T21:01:37.545Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/0d/41c602003e8a9b16fe1e7eadf62c7bfba9d5474370b24200bf48b315f45f/propcache-0.5.2-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:6e7b8719005dd1175be4ab1cd25e9b98659a5e0347331506ec6760d2773a7fb5", size = 64781, upload-time = "2026-05-08T21:01:38.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f3/38e66b1856e9bd079deea015bc4a55f7767c0e4db2f7dcf69e7e680ba4ce/propcache-0.5.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:51f96d685ab16e88cab128cd37a52c5da540809c8b879fa047731bfcb4ad35a4", size = 62570, upload-time = "2026-05-08T21:01:40.415Z" },
+    { url = "https://files.pythonhosted.org/packages/95/ca/bbfe9b910ce57dde8bb4876b4520fc02a4e89497c10de26be936758a3aaa/propcache-0.5.2-cp314-cp314-win32.whl", hash = "sha256:cc6fc3cc62e8501d3ed62894425040d2728ecddb1ed072737a5c70bd537aa9f0", size = 39436, upload-time = "2026-05-08T21:01:41.654Z" },
+    { url = "https://files.pythonhosted.org/packages/61/d2/45c9defbaa1ea297035d9d4cce9e8f80daafbf19319c6007f157c6256ea9/propcache-0.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:81e3a30b0bb60caa22033dd0f8a3618d1d67356212514f62c57db75cb0ef410c", size = 42373, upload-time = "2026-05-08T21:01:43.041Z" },
+    { url = "https://files.pythonhosted.org/packages/44/68/9ea5103f41d5217d7d6ec24db90018e23aebec070c3f9a6e54d12b841fd8/propcache-0.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:0d2c9bf8528f135dbb805ce027567e09164f7efa51a2be07458a2c0420f292d0", size = 38554, upload-time = "2026-05-08T21:01:44.336Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/81/fadf555f42d3b762eea8a53950b0489fdc0aa9da5f8ed9e10ce0a4e01b48/propcache-0.5.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4bc8ff1feffc6a61c7002ffe84634c41b822e104990ae009f44a0834430070bb", size = 99395, upload-time = "2026-05-08T21:01:45.883Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/c9/c61e134a686949cf7971af3a390148b1156f7be81c73bc0cd12c873e2d48/propcache-0.5.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:79aa3ff0a9b566633b642fa9caf7e21ed1c13d6feca718187873f199e1514078", size = 56653, upload-time = "2026-05-08T21:01:47.307Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/73/daf935ea7048ddd7ec8eec5345b4a40b619d2d178b3c0a0900796bc3c794/propcache-0.5.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1b31822f4474c4036bae62de9402710051d431a606d6a0f907fec79935a071aa", size = 56914, upload-time = "2026-05-08T21:01:48.573Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9f/aba959b435ea18617edd7cf0a7ad0b9c574b8fc7e3d2cd55fb59cb255d33/propcache-0.5.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:13fef48778b5a2a756523fdb781326b028ca75e32858b04f2cdd19f394564917", size = 62567, upload-time = "2026-05-08T21:01:49.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a1/859942de9a791ff42f6141736f5b37749b8f53e65edfa49638c67dd67e6a/propcache-0.5.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8b73ab70f1a3351fbc71f663b3e645af6dd0329100c353081cf69c37433fc6fe", size = 65542, upload-time = "2026-05-08T21:01:51.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/61/315bc0fd6c0fc7f80a528b8afd209e5fc4a875ea79571b91b8f50f442907/propcache-0.5.2-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5538d2c13d93e4698af7e092b57bc7298fd35d1d58e656ae18f23ee0d0378e03", size = 66845, upload-time = "2026-05-08T21:01:52.539Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f7/9f8122e3132e8e354ac41975ef8f1099be7d5a16bc7ae562734e993665c0/propcache-0.5.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cd645f03898405cabe694fb8bc35241e3a9c332ec85627584fe3de201452b335", size = 63985, upload-time = "2026-05-08T21:01:53.847Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/54/c317819ec157cbf6f35df9df9657a6f82daf34d5faf15948b2f639c2192e/propcache-0.5.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a473b3440261e0c60706e732b2ed2f517857344fc21bf48fdfe211e2d98eb285", size = 63999, upload-time = "2026-05-08T21:01:55.179Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/56/387e3f7dfce0a9233df41fb888aa1c30222cb4bbbf09537c02dd9bd85fe2/propcache-0.5.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7afa37062e6650640e932e4cc9297d81f9f42d9944029cc386b8247dea4da837", size = 62779, upload-time = "2026-05-08T21:01:57.489Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/9c/596784cb5824ed61ee960d3f8655a3f0993e107c6e98ab6c818b7fb92ccb/propcache-0.5.2-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:8a90efd5777e996e42d568db9ac740b944d691e565cbfd31b2f7832f9184b2b8", size = 59796, upload-time = "2026-05-08T21:01:58.736Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/3d/1a6cfa1726a48542c1e8784a0761421476a5b68e09b7f36bf95eb954aaba/propcache-0.5.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:f19bb891234d72535764d703bfed1153cc34f4214d5bd7150aee1eec9e8f4366", size = 66023, upload-time = "2026-05-08T21:02:00.228Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/0e/05fd6990369477076e4e280bcb970de760fddf0161a46e988bc95f7940ec/propcache-0.5.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:32775082acd2d807ee3db715c7770d38767b817870acfa08c29e057f3c4d5b56", size = 64448, upload-time = "2026-05-08T21:02:01.888Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/86/5f8da315a4309c62c10c0b2516b17492d5d3bbe1bb862b96604db67e2a37/propcache-0.5.2-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:9282fb1a3bccd038da9f768b927b24a0c753e466c086b7c4f3c6982851eefb2d", size = 67329, upload-time = "2026-05-08T21:02:03.484Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d3/3368efe79ab21f0cdf86ef49895811c9cc933131d4cde1f28a624e22e712/propcache-0.5.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cc49723e2f60d6b32a0f0b08a3fd6d13203c07f1cd9566cfce0f12a917c967a2", size = 65172, upload-time = "2026-05-08T21:02:04.745Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/07/127e8b0bacfb325396196f9d976a22453049b89b9b2b08477cc3145faa44/propcache-0.5.2-cp314-cp314t-win32.whl", hash = "sha256:2d7aa89ebca5acc98cba9d1472d976e394782f587bad6661003602a619fd1821", size = 43813, upload-time = "2026-05-08T21:02:06.025Z" },
+    { url = "https://files.pythonhosted.org/packages/88/fb/46dad6c0ae49ed230ab1b16c890c2b6314e2403e6c412976f4a72d64a527/propcache-0.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d447bb0b3054be5818458fbb171208b1d9ff11eba14e18ca18b90cbb45767370", size = 47764, upload-time = "2026-05-08T21:02:07.353Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c4/a47d0a63aa309d10d59ede6e9d4cff03a344a79d1f0f4cd0cd74997b53e0/propcache-0.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:fe67a3d11cd9b4efabfa45c3d00ffba2b26811442a73a581a94b67c2b5faccf6", size = 41140, upload-time = "2026-05-08T21:02:09.065Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
 ]
 
 [[package]]
@@ -1762,6 +2000,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1846,6 +2093,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3a/38/c61bfcf62a7b572b5e9363a802ff92559cb427ee963048e1442e3aef7490/typeguard-2.13.3.tar.gz", hash = "sha256:00edaa8da3a133674796cf5ea87d9f4b4c367d77476e185e80251cc13dfbb8c4", size = 40604, upload-time = "2021-12-10T21:09:39.158Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/bb/d43e5c75054e53efce310e79d63df0ac3f25e34c926be5dffb7d283fb2a8/typeguard-2.13.3-py3-none-any.whl", hash = "sha256:5e3e3be01e887e7eafae5af63d1f36c849aaa94e3a0112097312aabfa16284f1", size = 17605, upload-time = "2021-12-10T21:09:37.844Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/78/fda3361b56efc27944f24225f6ecd13d96d6fcfe37bd0eb34e2f4c63f9fc/typer-0.27.0.tar.gz", hash = "sha256:629bd12ea5d13a17148125d9a264f949eb171fb3f120f9b04d85873cab054fa5", size = 203430, upload-time = "2026-07-15T19:21:07.007Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/03/26a383c9e58c213199d1aad1c3d353cfc22d4444ec6d2c0bf8ad02523843/typer-0.27.0-py3-none-any.whl", hash = "sha256:6f4b27631e47f077871b7dc30e933ec0131c1390fbe0e387ea5574b5bac9ccf1", size = 122716, upload-time = "2026-07-15T19:21:05.553Z" },
 ]
 
 [[package]]
@@ -1984,6 +2246,15 @@ wheels = [
 ]
 
 [[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
+]
+
+[[package]]
 name = "websockets"
 version = "16.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2024,6 +2295,54 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/b2/b6987faf330f5af5c787a2610124c2e8403d51724f9001ec4fff6311fe7a/websockets-16.1.1-cp314-cp314t-win32.whl", hash = "sha256:8483c2096363120eea8b07c06ae7304d520f686665fffd4811fad423930a65d7", size = 179729, upload-time = "2026-07-17T22:50:53.269Z" },
     { url = "https://files.pythonhosted.org/packages/a2/6e/fbac6ed878dd362fbad7d415fa4f84d38e3e33fed8cde45c64e783acf826/websockets-16.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:bcce07e23e5769375158f5efdcdafa8d5cd014b93c6683865b840ed65b96f231", size = 180072, upload-time = "2026-07-17T22:50:54.969Z" },
     { url = "https://files.pythonhosted.org/packages/be/4d/2d0d67834092e354d2b0498f014a41249a89556bc406cf86f3e1557bb463/websockets-16.1.1-py3-none-any.whl", hash = "sha256:6abbd3e82c731c8e531714466acd5d87b5e88ac3243465337ba71d68e23ae7e3", size = 173814, upload-time = "2026-07-17T22:51:04.184Z" },
+]
+
+[[package]]
+name = "yarl"
+version = "1.24.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "multidict" },
+    { name = "propcache" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/31/33/ebe9e3d1f86c7a0b51094c0a146392045ca1631d2664889539dec8088a33/yarl-1.24.5.tar.gz", hash = "sha256:e81b83143bee16329c23db3c1b2d82b29892fcbcb849186d2f6e98a5abe9a57f", size = 228679, upload-time = "2026-07-20T02:07:45.435Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/08/5f3085fef9564217074db9dd8573de1795bc82cde61a7ad10b6a7234a569/yarl-1.24.5-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2729fcfc4f6a596fb0c50f32090400aa9367774ac296a00387e65098c0befa76", size = 135680, upload-time = "2026-07-20T02:06:33.273Z" },
+    { url = "https://files.pythonhosted.org/packages/98/35/ba9436e579bd48a8801f2021d842d9ab4994c26e4c7dd3a4c1f1bcb57a9e/yarl-1.24.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ff330d3c30db4eb6b01d79e29d2d0b407a7ecad39cfd9ec993ece57396a2ec0d", size = 97395, upload-time = "2026-07-20T02:06:35.259Z" },
+    { url = "https://files.pythonhosted.org/packages/18/a9/a07f76f3c44e02b25cc743af5ef93eef27f7013eadca770451b6a6ccb5db/yarl-1.24.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e42d75862735da90e7fc5a7b23db0c976f737113a54b3c9777a9b665e9cbff75", size = 97223, upload-time = "2026-07-20T02:06:37.216Z" },
+    { url = "https://files.pythonhosted.org/packages/77/f7/a9a1d6fa7dd9e388f95b30f6ad3ec4e285f6c8f61f44ce16070c3fcfe414/yarl-1.24.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a3732e66413163e72508da9eff9ce9d2846fde51fae45d3605393d3e6cd303e9", size = 108777, upload-time = "2026-07-20T02:06:39.292Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/44/e0b86c302471fabd6f02808ecf2ac52b8412b624787849d4bf2cdb466f6f/yarl-1.24.5-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:5b8ee53be440a0cffc991a27be3057e0530122548dbe7c0892df08822fce5ede", size = 103119, upload-time = "2026-07-20T02:06:41.456Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/16/9c16d180bf8faaf223225eb50e1245870ff1ae0e302a27153988e65c51fd/yarl-1.24.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:af3aefa655adb5869491fa907e652290386800ae99cc50095cba71e2c6aefdca", size = 116471, upload-time = "2026-07-20T02:06:43.696Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/8d/b219b9df28a02ce95cfbdd41d2f7caa5669d0ff979c1c9975697145e33c5/yarl-1.24.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2120b96872df4a117cde97d270bac96aea7cc52205d305cf4611df694a487027", size = 115974, upload-time = "2026-07-20T02:06:45.874Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e8/f20557aca240d88e69850ad1ee91756821d094bb1310565c04d25c6682a2/yarl-1.24.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:66410eb6345d467151934b49bfa70fb32f5b35a6140baa40ad97d6436abea2e9", size = 110830, upload-time = "2026-07-20T02:06:47.852Z" },
+    { url = "https://files.pythonhosted.org/packages/db/18/199b85109a53eeca64ee19c9cca228287e8e4ab0cc1a09b28f530e65cce0/yarl-1.24.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4af7b7e1be0a69bee8210735fe6dcfc38879adfac6d62e789d53ba432d1ffa41", size = 110054, upload-time = "2026-07-20T02:06:49.84Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/2f/ed28147f8cd7f48c49367c90713b30a555284b6105a6a56f3a05568da795/yarl-1.24.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fa139875ff98ab97da323cfadfaff08900d1ad42f1b5087b0b812a55c5a06373", size = 108312, upload-time = "2026-07-20T02:06:51.835Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/c5/55e16ae0a5c227cea8df1c6871ba57d614a34243146c05729caf2a1bd9c5/yarl-1.24.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:0055afc45e864b92729ac7600e2d102c17bef060647e74bca75fa84d66b9ff36", size = 103662, upload-time = "2026-07-20T02:06:54.061Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/ea/dbd7c2caec459c9a426f18b02688ecbfb58620d0f6a3422d24769fbaf8ab/yarl-1.24.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f0e466ed7511fe9d459a819edbc6c2585c0b6eabde9fa8a8947552468a7a6ef0", size = 116090, upload-time = "2026-07-20T02:06:56.015Z" },
+    { url = "https://files.pythonhosted.org/packages/06/84/39ce4ce3059e07fece5fbdbee8c4053406af9aca911ce9fa5f8548aab6af/yarl-1.24.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:f141474e85b7e54998ec5180530a7cda99ab29e282fa50e0756d89981a9b43c5", size = 109523, upload-time = "2026-07-20T02:06:57.926Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/8b/71ff44137b405c64a7788075669c24010019f57a7464b78c3a6cbee539d9/yarl-1.24.5-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:e2935f8c39e3b03e83519292d78f075189978f3f4adc15a78144c7c8e2a1cba5", size = 116084, upload-time = "2026-07-20T02:06:59.868Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c0/423078fdd4042e1862c11f0ffd977a0ffa393783c12bee94685923bc189e/yarl-1.24.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9d1216a7f6f77836617dba35687c5b78a4170afc3c3f18fc788f785ba26565c4", size = 111006, upload-time = "2026-07-20T02:07:01.907Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/52/6daa2ee9d95e5c98b8128f8df91eb692eb423ab274b8cf08db52152fad26/yarl-1.24.5-cp314-cp314-win_amd64.whl", hash = "sha256:5ba4f78df2bcc19f764a4b26a8a4f5049c110090ad5825993aacb052bf8003ad", size = 99215, upload-time = "2026-07-20T02:07:03.852Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0e/464a847d7359e0da75dd9fc5c1d1aa35d0159ea31e5f8e66a3c1c29ff3d0/yarl-1.24.5-cp314-cp314-win_arm64.whl", hash = "sha256:9e4e16c73d717c5cf27626c524d0a2e261ad20e46932b2670f64ad5dde23e26f", size = 94566, upload-time = "2026-07-20T02:07:06.074Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/55/e03acc4446772660bc335e86e41ef31e4d0d838fd641531a11a5ee33b493/yarl-1.24.5-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:e1ae548a9d901adca07899a4147a7c826bbcc06239d3ce9a59f57886a28a4c88", size = 142533, upload-time = "2026-07-20T02:07:08.284Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/71/4acd3a1fc7cf14345cdb302665ecd2097f62c365b4f14ca17d4f37775cf9/yarl-1.24.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:ff405d91509d88e8d44129cd87b18d70acd1f0c1aeabd7bc3c46792b1fe2acba", size = 100776, upload-time = "2026-07-20T02:07:10.197Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0b/cfb76b7fe99686db264bff829779a539d923e7564ffd7ef18da6c54c3774/yarl-1.24.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:47e98aab9d8d82ff682e7b0b5dded33bf138a32b817fcf7fa3b27b2d7c412928", size = 100913, upload-time = "2026-07-20T02:07:12.357Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/3f/7116e782992abbd4fb6948488aec72078895e929a23078290739e8396fce/yarl-1.24.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f0a658a6d3fafee5c6f63c58f3e785c8c43c93fbc02bf9f2b6663f8185e0971f", size = 106507, upload-time = "2026-07-20T02:07:14.173Z" },
+    { url = "https://files.pythonhosted.org/packages/33/90/d4d2d73ee78229cc889872eb8e085d8f5c6f51abdb178409fd9b23cf74fd/yarl-1.24.5-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4377407001ca3c057773f44d8ddd6358fa5f691407c1ba92210bd3cf8d9e4c95", size = 99219, upload-time = "2026-07-20T02:07:16.019Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/fa/a6df1a9bccd644eec00abee0dff4277416222cec435330fd1f2858523ec1/yarl-1.24.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7c0494a31a1ac5461a226e7947a9c9b78c44e1dc7185164fa7e9651557a5d9bc", size = 111804, upload-time = "2026-07-20T02:07:18.141Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/9e/7b2a1f4bcc20e9447156dd2b1c4d01f70d9df0759025ee7d09a84ffae134/yarl-1.24.5-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a7cff474ab7cd149765bb784cf6d78b32e18e20473fb7bda860bce98ab58e9da", size = 110943, upload-time = "2026-07-20T02:07:20.06Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ff/22c92affb0f9b623ca753d27d968b5625b868f12c6378d049d55ae247643/yarl-1.24.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cbb833ccacdb5519eff9b8b71ee618cc2801c878e77e288775d77c3a2ced858a", size = 108251, upload-time = "2026-07-20T02:07:22.217Z" },
+    { url = "https://files.pythonhosted.org/packages/45/44/5769b96298c1e195fb412997b6090af2a84105cf59c17613558a2d011d1f/yarl-1.24.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:82f75e05912e84b7a0fe57075d9c59de3cb352b928330f2eb69b2e1f54c3e1f0", size = 106025, upload-time = "2026-07-20T02:07:24.083Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/40/009e8e791fd9762c0e1567e69248acb4f49064597e1680874c16dd8bb798/yarl-1.24.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:16a2f5010280020e90f5330257e6944bc33e73593b136cc5a241e6c1dc292498", size = 106573, upload-time = "2026-07-20T02:07:26.248Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c6/b7480578f8a0a80946f36ad6df547ecec704f9ba69d2de60f8aa6f1c1cbf/yarl-1.24.5-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:ffcd54362564dc1a30fb74d8b8a6e5a6b11ebd5e27266adc3b7427a21a6c9104", size = 100751, upload-time = "2026-07-20T02:07:28.098Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/27/4476f3360b91a48c5cf125e91f59a3bd35299d84a431a258d57f5977bb11/yarl-1.24.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0465ec8cedc2349b97a6b595ace64084a50c6e839eca40aa0626f38b8350e331", size = 111643, upload-time = "2026-07-20T02:07:30.88Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4b/5cdd3e5ee944e8af31e52f6cd3d3af5fd7b937e036ccbbba2c9ffebede95/yarl-1.24.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:4db9aecb141cb7a5447171b57aa1ed3a8fee06af40b992ffc31206c0b0121550", size = 106312, upload-time = "2026-07-20T02:07:33.06Z" },
+    { url = "https://files.pythonhosted.org/packages/18/86/f406b0c2a6f99575de2da671ef47aa06f89a5be83a27a46971c3b86cecdb/yarl-1.24.5-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:f540c013589084679a6c7fac07096b10159737918174f5dfc5e11bf5bca4dfe6", size = 110379, upload-time = "2026-07-20T02:07:35.155Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/6c/9f3adfbd3b30b4fa0f7ccb3a83eba2c1152d3fff554d535e640ba0f7ba2b/yarl-1.24.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a61834fb15d81322d872eaafd333838ae7c9cea84067f232656f75965933d047", size = 108497, upload-time = "2026-07-20T02:07:37.35Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/37/91eb2e5ca883a529c1b390348a74cd9fc0512171727f547ce70bfe02be5c/yarl-1.24.5-cp314-cp314t-win_amd64.whl", hash = "sha256:5c88e5815a49d289e599f3513aa7fde0bc2092ff188f99c940f007f90f53d104", size = 102450, upload-time = "2026-07-20T02:07:39.578Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f4/ed5c402ac8fde4403ed3366c2716bfddc8a6677ebd59f3d62772cc7fe468/yarl-1.24.5-cp314-cp314t-win_arm64.whl", hash = "sha256:cf139c02f5f23ef6532040a30ff662c00a318c952334f211046b8e60b7f17688", size = 97222, upload-time = "2026-07-20T02:07:41.55Z" },
+    { url = "https://files.pythonhosted.org/packages/61/02/962c1cbfc401a30c1d034dc67ff395f64b52302c6d62de556c1fca99acc0/yarl-1.24.5-py3-none-any.whl", hash = "sha256:a33700d13d9b7d84fd10947b09ff69fb9a792e519c8cb9764a3ca70baa6c23a7", size = 58612, upload-time = "2026-07-20T02:07:43.461Z" },
 ]
 
 [[package]]

--- a/web/src/api/config.ts
+++ b/web/src/api/config.ts
@@ -145,6 +145,7 @@ export const ENDPOINTS = {
     preview: '/v1/voices/preview',
     mistralCatalog: '/v1/voices/mistral/catalog',
     xaiCatalog: '/v1/voices/xai/catalog',
+    qwenCatalog: '/v1/voices/qwen/catalog',
     designPreviews: '/v1/voices/design/previews',
     designSave: '/v1/voices/design/save',
     cloneToMistral: '/v1/voices/clone-to-mistral',

--- a/web/src/api/services/voice-service.ts
+++ b/web/src/api/services/voice-service.ts
@@ -7,6 +7,7 @@ import type {
   ManualVoiceAssignmentPayload,
   MistralVoiceCatalog,
   PaginatedVoices,
+  QwenVoiceCatalog,
   Voice,
   VoiceCloneToMistralRequest,
   VoiceDesignPreviewsResponse,
@@ -134,6 +135,28 @@ export const listXaiCatalog = async (
   const qs = params.toString()
   const url = qs ? `${ENDPOINTS.voices.xaiCatalog}?${qs}` : ENDPOINTS.voices.xaiCatalog
   return httpClient.get<XaiVoiceCatalog>(url)
+}
+
+/**
+ * List Qwen (Alibaba) preset voices.
+ *
+ * Alibaba exposes no voice-list API for qwen-audio-3.0-tts, so the backend
+ * serves a static catalog.
+ *
+ * @param language - Optional language prefix filter (e.g. "en").
+ * @param gender - Optional gender filter.
+ * @returns Promise<QwenVoiceCatalog>
+ */
+export const listQwenCatalog = async (
+  language?: string,
+  gender?: string
+): Promise<QwenVoiceCatalog> => {
+  const params = new URLSearchParams()
+  if (language) params.set('language', language)
+  if (gender) params.set('gender', gender)
+  const qs = params.toString()
+  const url = qs ? `${ENDPOINTS.voices.qwenCatalog}?${qs}` : ENDPOINTS.voices.qwenCatalog
+  return httpClient.get<QwenVoiceCatalog>(url)
 }
 
 /**

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -589,6 +589,21 @@ export interface XaiVoiceCatalog {
   total: number
 }
 
+// Qwen (Alibaba) voice catalog (static preset list, not stored in DB)
+export interface QwenCatalogVoice {
+  id: string
+  name: string
+  gender: string | null
+  description: string | null
+  languages: string[] | null
+  model: string | null
+}
+
+export interface QwenVoiceCatalog {
+  items: QwenCatalogVoice[]
+  total: number
+}
+
 // Voice cloning
 export interface VoiceCloneToMistralRequest {
   professor_id: number

--- a/web/src/components/professors/ProfessorVoice.tsx
+++ b/web/src/components/professors/ProfessorVoice.tsx
@@ -14,22 +14,29 @@ import {
   generateVoiceDesignPreviews,
   getVoice,
   listMistralCatalog,
+  listQwenCatalog,
   listXaiCatalog,
   manualAssignVoice,
   previewVoice,
   saveDesignedVoice,
 } from '../../api/services/voice-service.js'
-import type { MistralCatalogVoice, VoiceDesignPreview, XaiCatalogVoice } from '../../api/types.js'
+import type {
+  MistralCatalogVoice,
+  QwenCatalogVoice,
+  VoiceDesignPreview,
+  XaiCatalogVoice,
+} from '../../api/types.js'
 import { RequireRole } from '../../auth/RequireRole'
 import { useLocale, useTranslations } from '../../i18n'
 import { Alert, Badge, Button, LoadingSpinner } from '../ui'
 
-type TtsBackendKey = 'elevenlabs' | 'mistral' | 'xai'
+type TtsBackendKey = 'elevenlabs' | 'mistral' | 'xai' | 'qwen'
 
 const BACKEND_OPTIONS: Array<{ value: TtsBackendKey; label: string }> = [
   { value: 'elevenlabs', label: 'ElevenLabs' },
   { value: 'mistral', label: 'Voxtral (Mistral)' },
   { value: 'xai', label: 'xAI (Grok)' },
+  { value: 'qwen', label: 'Qwen (Alibaba)' },
 ]
 
 /** Display-friendly name for a TTS backend. */
@@ -38,6 +45,7 @@ const backendLabel = (backend: string | null | undefined): string => {
     elevenlabs: 'ElevenLabs',
     mistral: 'Voxtral',
     xai: 'xAI (Grok)',
+    qwen: 'Qwen (Alibaba)',
   }
   return (backend && map[backend]) ?? 'ElevenLabs'
 }
@@ -189,6 +197,92 @@ const XaiVoiceCard: Component<{
 }
 
 // ---------------------------------------------------------------------------
+// Voice card for Qwen (Alibaba) preset voices
+// ---------------------------------------------------------------------------
+const QwenVoiceCard: Component<{
+  voice: QwenCatalogVoice
+  isSelected: boolean
+  isPreviewing: boolean
+  onSelect: () => void
+  onPreview: () => void
+}> = (props) => {
+  const t = useTranslations()
+  const attrs = createMemo(() => {
+    const v = props.voice
+    const items: Array<{ label: string; value: string }> = []
+    if (v.gender) {
+      const genderKey = v.gender.toLowerCase() as 'male' | 'female' | 'neutral'
+      const localizedGender = t().professorDetail.genders[genderKey] || v.gender
+      items.push({ label: t().professorDetail.fields.gender, value: localizedGender })
+    }
+    if (v.languages?.length) {
+      items.push({ label: t().professorVoice.langLabel || 'Lang', value: v.languages.join(', ') })
+    }
+    return items
+  })
+  // Model tier badge (e.g. "flash" / "plus" from qwen-audio-3.0-tts-flash)
+  const tier = createMemo(() => {
+    const model = props.voice.model
+    if (!model) return null
+    const parts = model.split('-')
+    return parts[parts.length - 1]
+  })
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => {
+        props.onSelect()
+      }}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          props.onSelect()
+        }
+      }}
+      class={`arcane-card-sm p-4 text-left w-full transition-colors cursor-pointer ${
+        props.isSelected ? 'ring-2 ring-accent bg-accent/10' : 'hover:bg-surface-hover'
+      }`}
+    >
+      <div class="flex items-start justify-between gap-2">
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center gap-2">
+            <p class="font-semibold text-foreground truncate">{props.voice.name}</p>
+            <Show when={tier()}>
+              <Badge variant="secondary">{tier()}</Badge>
+            </Show>
+          </div>
+          <Show when={props.voice.description}>
+            <p class="text-xs text-muted mt-0.5 truncate">{props.voice.description}</p>
+          </Show>
+          <div class="flex flex-wrap gap-1.5 mt-1.5">
+            <For each={attrs()}>
+              {(attr) => (
+                <Badge variant="outline">
+                  <span class="text-muted mr-1">{attr.label}:</span> {attr.value}
+                </Badge>
+              )}
+            </For>
+          </div>
+        </div>
+        <button
+          type="button"
+          class="shrink-0 text-xs px-2 py-1 rounded bg-surface hover:bg-accent/20 text-accent transition-colors"
+          onClick={(e) => {
+            e.stopPropagation()
+            props.onPreview()
+          }}
+          disabled={props.isPreviewing}
+        >
+          {props.isPreviewing ? '...' : `▶ ${t().common.preview}`}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
 const ProfessorVoice: Component = () => {
@@ -223,7 +317,7 @@ const ProfessorVoice: Component = () => {
     if (!backendInitialized && voice) {
       backendInitialized = true
       const backend = voice.tts_backend
-      if (backend === 'mistral' || backend === 'xai') {
+      if (backend === 'mistral' || backend === 'xai' || backend === 'qwen') {
         setSelectedBackend(backend)
       } else {
         setSelectedBackend('elevenlabs')
@@ -269,6 +363,18 @@ const ProfessorVoice: Component = () => {
     return xaiCatalog()?.items.find((v) => v.id === id) ?? null
   })
 
+  // ---- Qwen voices (on-demand static preset catalog) ----
+  const [qwenCatalog] = createResource(
+    () => (selectedBackend() === 'qwen' ? true : null),
+    async (enabled) => (enabled ? listQwenCatalog() : undefined)
+  )
+  const [selectedQwenId, setSelectedQwenId] = createSignal<string | null>(null)
+  const selectedQwenVoice = createMemo(() => {
+    const id = selectedQwenId()
+    if (!id) return null
+    return qwenCatalog()?.items.find((v) => v.id === id) ?? null
+  })
+
   // ---- Audio preview ----
   const [previewAudioUri, setPreviewAudioUri] = createSignal<string | null>(null)
   const [isPreviewingId, setIsPreviewingId] = createSignal<string | null>(null)
@@ -297,6 +403,23 @@ const ProfessorVoice: Component = () => {
       const resp = await previewVoice({
         voice_id: voice.id,
         tts_backend: 'xai',
+        language: currentLocale(),
+      })
+      setPreviewAudioUri(resp.audio_data_uri)
+    } catch (e) {
+      console.error('Preview failed', e)
+    } finally {
+      setIsPreviewingId(null)
+    }
+  }
+
+  const handleQwenPreview = async (voice: QwenCatalogVoice) => {
+    setIsPreviewingId(voice.id)
+    setPreviewAudioUri(null)
+    try {
+      const resp = await previewVoice({
+        voice_id: voice.id,
+        tts_backend: 'qwen',
         language: currentLocale(),
       })
       setPreviewAudioUri(resp.audio_data_uri)
@@ -340,6 +463,14 @@ const ProfessorVoice: Component = () => {
       }
       externalId = voice.id
       ttsBackend = 'xai'
+    } else if (backend === 'qwen') {
+      const voice = selectedQwenVoice()
+      if (!voice) {
+        setAssignError(t().professorVoice.errorSelectVoice)
+        return
+      }
+      externalId = voice.id
+      ttsBackend = 'qwen'
     } else {
       const voice = selectedMistralVoice()
       if (!voice) {
@@ -498,6 +629,7 @@ const ProfessorVoice: Component = () => {
     setSelectedBackend(b)
     setSelectedMistralId(null)
     setSelectedXaiId(null)
+    setSelectedQwenId(null)
     setPreviewAudioUri(null)
     setAssignError('')
     setAssignSuccess('')
@@ -907,6 +1039,75 @@ const ProfessorVoice: Component = () => {
                           onSelect={() => setSelectedXaiId(voice.id)}
                           onPreview={() => {
                             void handleXaiPreview(voice)
+                          }}
+                        />
+                      )}
+                    </For>
+                  </div>
+                </Show>
+              </Show>
+
+              {/* Audio player for preview */}
+              <Show when={previewAudioUri()}>
+                <div class="mt-4 p-3 bg-surface rounded-lg">
+                  <p class="text-xs text-muted mb-2">{t().professorVoice.voicePreview}</p>
+                  <audio
+                    controls
+                    autoplay
+                    class="w-full max-w-md"
+                    src={previewAudioUri() ?? ''}
+                    aria-label="Voice preview audio"
+                  >
+                    <track
+                      kind="captions"
+                      src="data:text/vtt;charset=utf-8,WEBVTT%0A%0A"
+                      srclang="en"
+                      label="English captions"
+                      default
+                    />
+                    Your browser does not support the audio element.
+                  </audio>
+                </div>
+              </Show>
+            </div>
+          </Show>
+
+          {/* Qwen: voice browsing grid (static preset catalog) */}
+          <Show when={selectedBackend() === 'qwen'}>
+            <div class="space-y-4">
+              <div class="flex items-center justify-between">
+                <p class="text-sm text-muted">{t().professorVoice.browseQwen}</p>
+                <Show when={selectedQwenVoice()}>
+                  <Button
+                    variant="primary"
+                    onClick={() => void handleAssign()}
+                    disabled={isAssigning()}
+                  >
+                    {isAssigning()
+                      ? t().professorVoice.assigning
+                      : t().professorVoice.assignSpecificVoice.replace(
+                          '{name}',
+                          selectedQwenVoice()?.name || ''
+                        )}
+                  </Button>
+                </Show>
+              </div>
+
+              <Show when={!qwenCatalog.loading} fallback={<LoadingSpinner />}>
+                <Show
+                  when={(qwenCatalog()?.items.length ?? 0) > 0}
+                  fallback={<p class="text-muted text-sm">{t().professorVoice.noQwenVoices}</p>}
+                >
+                  <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                    <For each={qwenCatalog()?.items ?? []}>
+                      {(voice) => (
+                        <QwenVoiceCard
+                          voice={voice}
+                          isSelected={selectedQwenId() === voice.id}
+                          isPreviewing={isPreviewingId() === voice.id}
+                          onSelect={() => setSelectedQwenId(voice.id)}
+                          onPreview={() => {
+                            void handleQwenPreview(voice)
                           }}
                         />
                       )}

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -425,6 +425,8 @@ export const en = {
     noMistralVoices: 'No Mistral voices found. Check that MISTRAL_API_KEY is configured.',
     browseXai: 'Browse xAI (Grok) voices and preview them before assigning.',
     noXaiVoices: 'No xAI voices found. Check that XAI_API_KEY is configured.',
+    browseQwen: 'Browse Qwen (Alibaba) voices and preview them before assigning.',
+    noQwenVoices: 'No Qwen voices found. Check that ALIBABA_API_KEY is configured.',
     voicePreview: 'Voice Preview',
     assignVoiceId: 'Paste an existing ElevenLabs voice ID to assign it to this professor.',
     assignButton: 'Assign',

--- a/web/src/i18n/locales/es.ts
+++ b/web/src/i18n/locales/es.ts
@@ -428,6 +428,9 @@ export const es = {
       'No se encontraron voces de Mistral. Verifique que MISTRAL_API_KEY esté configurada.',
     browseXai: 'Explore las voces de xAI (Grok) y escúchelas antes de asignarlas.',
     noXaiVoices: 'No se encontraron voces de xAI. Verifique que XAI_API_KEY esté configurada.',
+    browseQwen: 'Explore las voces de Qwen (Alibaba) y escúchelas antes de asignarlas.',
+    noQwenVoices:
+      'No se encontraron voces de Qwen. Verifique que ALIBABA_API_KEY esté configurada.',
     voicePreview: 'Vista Previa de Voz',
     assignVoiceId: 'Pegue un ID de voz de ElevenLabs existente para asignarlo a este profesor.',
     assignButton: 'Asignar',

--- a/web/src/i18n/locales/fr.ts
+++ b/web/src/i18n/locales/fr.ts
@@ -426,6 +426,8 @@ export const fr = {
     noMistralVoices: 'Aucune voix Mistral trouvée. Vérifiez que MISTRAL_API_KEY est configurée.',
     browseXai: 'Parcourir les voix xAI (Grok) et les écouter avant de les assigner.',
     noXaiVoices: 'Aucune voix xAI trouvée. Vérifiez que XAI_API_KEY est configurée.',
+    browseQwen: 'Parcourir les voix Qwen (Alibaba) et les écouter avant de les assigner.',
+    noQwenVoices: 'Aucune voix Qwen trouvée. Vérifiez que ALIBABA_API_KEY est configurée.',
     voicePreview: 'Aperçu de la Voix',
     assignVoiceId: "Collez un ID de voix ElevenLabs existant pour l'assigner à ce professeur.",
     assignButton: 'Assigner',

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -422,6 +422,8 @@ export const zh = {
     noMistralVoices: '未找到 Mistral 声音。请检查是否配置了 MISTRAL_API_KEY。',
     browseXai: '浏览 xAI (Grok) 声音并在分配前预览。',
     noXaiVoices: '未找到 xAI 声音。请检查是否配置了 XAI_API_KEY。',
+    browseQwen: '浏览 Qwen (阿里巴巴) 声音并在分配前预览。',
+    noQwenVoices: '未找到 Qwen 声音。请检查是否配置了 ALIBABA_API_KEY。',
     voicePreview: '声音预览',
     assignVoiceId: '粘贴现有的 ElevenLabs 声音 ID 以分配给该教授。',
     assignButton: '分配',


### PR DESCRIPTION
## What & why

Adds a fourth TTS backend, `qwen` (Alibaba Model Studio's newly released **qwen-audio-3.0-tts**), alongside ElevenLabs, Mistral (Voxtral), and xAI (Grok). It follows the xAI backend pattern end to end so professors can be assigned a Qwen preset voice from the voice-selection UI.

## Changes

**Backend**
- New `artificial_u/integrations/qwen/` package:
  - `QwenTTSClient` — wraps the official `dashscope` SDK `SpeechSynthesizer` (the 3.0 models are WebSocket-only). Requests MP3 output so `TTSService`'s existing chunk-concat + ffmpeg remux pipeline works unchanged. Retry/backoff mirrors the xAI client. Resolves flash vs. plus model from the chosen voice.
  - `QwenVoiceManager` — static 14-voice preset catalog (Alibaba exposes no voice-list API for these models).
- `QwenTTSBackend` adapter, registered in `integrations/tts/factory.py`.
- `ALIBABA_API_KEY`, `TTS_QWEN_MODEL`, `ALIBABA_TTS_WSS_URL` in settings/defaults, wired through `system.py`. Explicit `qwen` branch in the speech processor.

**API + frontend**
- `GET /api/v1/voices/qwen/catalog` (static list, filterable by language/gender).
- `qwen` enrichment branch in `VoiceService.manual_voice_assignment_generic` — extracted per-provider enrichment into a `_enrich_generic_voice` helper to stay under the flake8 complexity limit. Preview and assign already work generically.
- New **Qwen (Alibaba)** tab in `ProfessorVoice.tsx` with a `QwenVoiceCard` (name, description, gender, flash/plus tier badge), plus `types.ts`/`config.ts`/`voice-service.ts` and i18n keys in en/es/fr/zh.

**Tests / CI / docs**
- New `tests/unit/integrations/test_qwen_tts.py` (13 tests), api-key assertions in `test_api_keys.py` + `conftest.py`, `ALIBABA_API_KEY` added to both CI workflows, speech-processor test, `scripts/seed_qwen_voices.py`, and `docs/configuration.md`.

## Verification

- All 344 unit tests pass; backend `black`/`isort`/`flake8` and frontend `eslint`/`biome`/`stylelint`/`build` all clean.
- Catalog endpoint returns correct data with language/gender filters.
- Live smoke test confirms the integration is correct up to the auth boundary (well-formed SDK call, model, voice, MP3 request).

## ⚠️ Reviewer note — region availability

**qwen-audio-3.0-tts is hosted only in the Singapore and Beijing regions, not us-east-1 (Virginia).** Verified by probing with a real key:

| Region | HTTP text-gen | WebSocket TTS |
|---|---|---|
| us-east-1 (`dashscope-us`) | 200 (key valid) | **404** — no websocket TTS route |
| Singapore (`dashscope-intl`) | 401 | **401 InvalidApiKey** — route/model exist, key rejected |
| Beijing (`dashscope`) | — | 401 InvalidApiKey |

Alibaba API keys are region-locked, so **a Singapore- (or Beijing-) region `ALIBABA_API_KEY` is required** to generate audio. The default `ALIBABA_TTS_WSS_URL` is set to Singapore (`dashscope-intl`) accordingly — a us-east-1 default provably cannot serve this model.

## Deferred
- Voice cloning ("clone-to-qwen") and Voice Design — the international `qwen-voice-enrollment` cloning API currently targets only the `qwen3-tts-vc` family, not 3.0, and Voice Design has no international API docs yet. A clone-to-qwen flow can later mirror the existing clone-to-mistral feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)